### PR TITLE
feat: add locale support

### DIFF
--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -2,45 +2,33 @@ import { MemoryRouter } from "./MemoryRouter";
 
 describe("MemoryRouter", () => {
   const memoryRouter = new MemoryRouter();
-  function currentRoute() {
-    const { pathname, query, asPath, locale } = memoryRouter;
-
-    return { pathname, query, asPath, locale };
-  }
 
   it("should start empty", () => {
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "",
-        "locale": undefined,
-        "pathname": "",
-        "query": Object {},
-      }
-    `);
+    expect(memoryRouter).toMatchObject({
+      asPath: "",
+      pathname: "",
+      query: {},
+      locale: undefined,
+    })
   });
   it("pushing URLs should update the route", () => {
     memoryRouter.push(`/one/two/three`);
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three",
-        "locale": undefined,
-        "pathname": "/one/two/three",
-        "query": Object {},
-      }
-    `);
+
+    expect(memoryRouter).toMatchObject({
+      asPath: "/one/two/three",
+      pathname: "/one/two/three",
+      query: {},
+    })
 
     memoryRouter.push(`/one/two/three?four=4&five=`);
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three?four=4&five=",
-        "locale": undefined,
-        "pathname": "/one/two/three",
-        "query": Object {
-          "five": "",
-          "four": "4",
-        },
-      }
-    `);
+    expect(memoryRouter).toMatchObject({
+      asPath: "/one/two/three?four=4&five=",
+      pathname: "/one/two/three",
+      query: {
+        five: "",
+        four: "4",
+      },
+    });
   });
   it("pushing should trigger the routeChangeComplete event", () => {
     const routeChangeComplete = jest.fn();
@@ -58,96 +46,73 @@ describe("MemoryRouter", () => {
 
   it("pushing UrlObjects should update the route", () => {
     memoryRouter.push({ pathname: "/one" });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one",
-        "locale": undefined,
-        "pathname": "/one",
-        "query": Object {},
-      }
-    `);
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one",
+        pathname: "/one",
+        query: {},
+    });
 
     memoryRouter.push({
       pathname: "/one/two/three",
       query: { four: "4", five: "" },
     });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three?four=4&five=",
-        "locale": undefined,
-        "pathname": "/one/two/three",
-        "query": Object {
-          "five": "",
-          "four": "4",
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one/two/three?four=4&five=",
+        pathname: "/one/two/three",
+        query: {
+          five: "",
+          four: "4",
         },
-      }
-    `);
+      });
   });
   it("pushing UrlObjects should inject slugs", () => {
     memoryRouter.push({ pathname: "/one/[id]", query: { id: "two" } });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two",
-        "locale": undefined,
-        "pathname": "/one/[id]",
-        "query": Object {
-          "id": "two",
-        },
-      }
-    `);
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one/two",
+        pathname: "/one/[id]",
+        query: {
+          id: "two",
+        }
+    });
 
     memoryRouter.push({ pathname: "/one/[id]/three", query: { id: "two" } });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three",
-        "locale": undefined,
-        "pathname": "/one/[id]/three",
-        "query": Object {
-          "id": "two",
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one/two/three",
+        pathname: "/one/[id]/three",
+        query: {
+          id: "two",
         },
-      }
-    `);
+    });
 
     memoryRouter.push({
       pathname: "/one/[id]/three",
       query: { id: "two", four: "4" },
     });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three?four=4",
-        "locale": undefined,
-        "pathname": "/one/[id]/three",
-        "query": Object {
-          "four": "4",
-          "id": "two",
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one/two/three?four=4",
+        pathname: "/one/[id]/three",
+        query:  {
+          four: "4",
+          id: "two",
         },
-      }
-    `);
+    });
     memoryRouter.push({
       pathname: "/one/[id]/three/[four]",
       query: { id: "two", four: "4" },
     });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/one/two/three/4",
-        "locale": undefined,
-        "pathname": "/one/[id]/three/[four]",
-        "query": Object {
-          "four": "4",
-          "id": "two",
+    expect(memoryRouter).toMatchObject({
+        asPath: "/one/two/three/4",
+        pathname: "/one/[id]/three/[four]",
+        query: {
+          four: "4",
+          id: "two",
         },
-      }
-    `);
+    });
   });
   it("push the locale", () => {
-    memoryRouter.push("/", "/", { locale: "en" });
-    expect(currentRoute()).toMatchInlineSnapshot(`
-      Object {
-        "asPath": "/",
-        "locale": "en",
-        "pathname": "/",
-        "query": Object {},
-      }
-    `);
+    memoryRouter.push("/", undefined, { locale: "en" });
+    expect(memoryRouter).toMatchObject({
+        locale: "en",
+    });
   })
 });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -115,4 +115,8 @@ describe("MemoryRouter", () => {
         locale: "en",
     });
   })
+
+  it('should support the locales property', () => {
+    expect(memoryRouter.locales).toEqual([ ]);
+  });
 });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -3,15 +3,16 @@ import { MemoryRouter } from "./MemoryRouter";
 describe("MemoryRouter", () => {
   const memoryRouter = new MemoryRouter();
   function currentRoute() {
-    const { pathname, query, asPath } = memoryRouter;
+    const { pathname, query, asPath, locale } = memoryRouter;
 
-    return { pathname, query, asPath };
+    return { pathname, query, asPath, locale };
   }
 
   it("should start empty", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "",
+        "locale": undefined,
         "pathname": "",
         "query": Object {},
       }
@@ -22,6 +23,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three",
+        "locale": undefined,
         "pathname": "/one/two/three",
         "query": Object {},
       }
@@ -31,6 +33,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three?four=4&five=",
+        "locale": undefined,
         "pathname": "/one/two/three",
         "query": Object {
           "five": "",
@@ -58,6 +61,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one",
+        "locale": undefined,
         "pathname": "/one",
         "query": Object {},
       }
@@ -70,6 +74,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three?four=4&five=",
+        "locale": undefined,
         "pathname": "/one/two/three",
         "query": Object {
           "five": "",
@@ -83,6 +88,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two",
+        "locale": undefined,
         "pathname": "/one/[id]",
         "query": Object {
           "id": "two",
@@ -94,6 +100,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three",
+        "locale": undefined,
         "pathname": "/one/[id]/three",
         "query": Object {
           "id": "two",
@@ -108,6 +115,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three?four=4",
+        "locale": undefined,
         "pathname": "/one/[id]/three",
         "query": Object {
           "four": "4",
@@ -122,6 +130,7 @@ describe("MemoryRouter", () => {
     expect(currentRoute()).toMatchInlineSnapshot(`
       Object {
         "asPath": "/one/two/three/4",
+        "locale": undefined,
         "pathname": "/one/[id]/three/[four]",
         "query": Object {
           "four": "4",
@@ -130,4 +139,15 @@ describe("MemoryRouter", () => {
       }
     `);
   });
+  it("push the locale", () => {
+    memoryRouter.push("/", "/", { locale: "en" });
+    expect(currentRoute()).toMatchInlineSnapshot(`
+      Object {
+        "asPath": "/",
+        "locale": "en",
+        "pathname": "/",
+        "query": Object {},
+      }
+    `);
+  })
 });

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -36,6 +36,13 @@ type UrlObject = {
 };
 type Url = string | UrlObject;
 
+// interface not exported by the package next/router
+interface TransitionOptions {
+  shallow?: boolean;
+  locale?: string | false;
+  scroll?: boolean;
+}
+
 /**
  * A base implementation of NextRouter that does nothing; all methods throw.
  */
@@ -48,8 +55,10 @@ export abstract class BaseRouter implements NextRouter {
   basePath = "";
   isFallback = false;
   events = new EventEmitter();
+  locale: string | undefined = undefined;
+  locales = [];
 
-  push = async (url: Url): Promise<boolean> => {
+  push = async (url: Url, as?: Url, options?: TransitionOptions): Promise<boolean> => {
     throw new Error("NotImplemented");
   };
   replace = async (url: Url): Promise<boolean> => {
@@ -76,8 +85,8 @@ export abstract class BaseRouter implements NextRouter {
  * TODO: Implement more methods!
  */
 export class MemoryRouter extends BaseRouter {
-  push = async (url: Url) => {
-    this.setMemoryRoute(url);
+  push = async (url: Url, as?: Url, options?: TransitionOptions) => {
+    this.setMemoryRoute(url, as, options);
 
     return true;
   };
@@ -92,13 +101,17 @@ export class MemoryRouter extends BaseRouter {
    * Sets the current route to the specified url.
    * @param url - String or Url-like object
    */
-  setMemoryRoute = (url: Url) => {
+  setMemoryRoute = (url: Url, as?: Url, options?: TransitionOptions) => {
     // Parse the URL if needed:
     const urlObject = typeof url === "string" ? parseUrl(url, true) : url;
 
     this.pathname = urlObject.pathname || "";
     this.query = urlObject.query || {};
     this.asPath = getRouteAsPath(this.pathname, this.query);
+
+    if (options?.locale) {
+      this.locale = options.locale;
+    }
 
     this.events.emit("routeChangeComplete");
   };

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -30,5 +30,16 @@ describe("router", () => {
         query: { bar: "baz" },
       });
     });
+
+    it("support the locales and locale properties", () => {
+      const { result } = renderHook(() => useRouter());
+      expect(result.current.locale).toBe(undefined);
+      expect(result.current.locales).toEqual([]);
+
+      act(() => {
+        result.current.push("/", undefined, { locale: "en" })
+      });
+      expect(result.current.locale).toBe("en");
+    });
   });
 });


### PR DESCRIPTION
- add `locale` and `locales` to MemoryRouter
- update `push` signature to match next/router and allow options

resolve #2 