### PR TITLE
fix(i18n): add typing to locales to fix the never type by default

### DIFF
--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -118,5 +118,7 @@ describe("MemoryRouter", () => {
 
   it('should support the locales property', () => {
     expect(memoryRouter.locales).toEqual([ ]);
+    memoryRouter.locales = ["en", "fr"];
+    expect(memoryRouter.locales).toEqual(["en", "fr"])
   });
 });

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -56,7 +56,7 @@ export abstract class BaseRouter implements NextRouter {
   isFallback = false;
   events = new EventEmitter();
   locale: string | undefined = undefined;
-  locales = [];
+  locales: string[] = [];
 
   push = async (url: Url, as?: Url, options?: TransitionOptions): Promise<boolean> => {
     throw new Error("NotImplemented");


### PR DESCRIPTION
Since the `memoryRouter.locales` is not typed nor has a default value. 
The type inferred is `never` instead of `string[]`

Added a small test case to make show the typing error.

@scottrippey do you want an issue with the PR?