### PR TITLE
Use Mitt events to avoid warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5633,6 +5633,11 @@
         "through2": "^2.0.0"
       }
     },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "mitt": "^3.0.0"
   }
 }

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import mitt from "mitt";
 import { parse as parseUrl, UrlWithParsedQuery } from "url";
 import { stringify as stringifyQueryString, ParsedUrlQuery } from "querystring";
 
@@ -43,6 +43,10 @@ interface TransitionOptions {
   scroll?: boolean;
 }
 
+type SupportedEventTypes = {
+  routeChangeComplete: undefined;
+};
+
 /**
  * A base implementation of NextRouter that does nothing; all methods throw.
  */
@@ -54,7 +58,7 @@ export abstract class BaseRouter implements NextRouter {
   asPath = "";
   basePath = "";
   isFallback = false;
-  events = new EventEmitter();
+  events = mitt<SupportedEventTypes>();
   locale: string | undefined = undefined;
   locales: string[] = [];
 


### PR DESCRIPTION
When rendering 10+ links, the native `events` module spits out a `MaxListeners` warning.

This PR switches to using `mitt`, which is the same library that Next uses, and does not have the `MaxListeners` warnings.