### PR TITLE
Add documentation for using `next/link`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,67 @@
 # `next-router-mock`
-An implementation of the Next.js Router that keeps the state of the "URL" in memory (does not read or write to the address bar).  Useful in tests and in Storybook.
-Inspired by [`react-router > MemoryRouter`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/MemoryRouter.md). 
+
+An implementation of the Next.js Router that keeps the state of the "URL" in memory (does not read or write to the
+address bar). Useful in tests and in Storybook. Inspired
+by [`react-router > MemoryRouter`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/MemoryRouter.md)
+.
 
 # API
 
-`next-router-mock` is a drop-in replacement for `next/router`. It exports both a default (singleton) router and the `useRouter` hook.
+`next-router-mock` is a drop-in replacement for `next/router`. It exports both a default (singleton) router and
+the `useRouter` hook.
 
 Install via NPM: `npm install --save-dev next-router-mock`
 
 ### Jest
+
+Simply drop-in the `next-router-mock` like this:
+
+```js
+jest.mock('next/router', () => require('next-router-mock'));
+// or this:
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+```
+
+> Note: it's better to mock `next/dist/client/router` instead of  `next/router`, because both `next/router` and `next/link` depend directly on this nested path.  It's also perfectly fine to mock both.
+
+Here's a full working example:
+
 ```js
 import router, { useRouter } from 'next/router';
 
-jest.mock('next/router', () => require('next-router-mock'));
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('router', () => {
-    it('supports the `push` and `replace` methods', () => {
-        router.push('/foo?bar=baz');
-        expect(router).toMatchObject({
-            asPath: '/foo?bar=baz',
-            pathname: '/foo',
-            query: { bar: 'baz' },
-        });
+  it('supports the `push` and `replace` methods', () => {
+    router.push('/foo?bar=baz');
+    expect(router).toMatchObject({
+      asPath: '/foo?bar=baz',
+      pathname: '/foo',
+      query: { bar: 'baz' },
     });
-    it('supports url object routes too', () => {
-        router.push({ 
-            pathname: '/foo/[id]', 
-            query: { id: '123', bar: 'baz' }, 
-        });
-        expect(router).toMatchObject({
-            asPath: '/foo/123?bar=baz',
-            pathname: '/foo/[id]',
-            query: { bar: 'baz' },
-        });
+  });
+  it('supports url object routes too', () => {
+    router.push({
+      pathname: '/foo/[id]',
+      query: { id: '123', bar: 'baz' },
     });
+    expect(router).toMatchObject({
+      asPath: '/foo/123?bar=baz',
+      pathname: '/foo/[id]',
+      query: { bar: 'baz' },
+    });
+  });
+
+  it('next/link can be tested too', () => {
+    render(<NextLink href="/example?foo=bar">Example Link</NextLink>);
+    fireEvent.click(screen.getByText('Example Link'));
+    expect(router).toMatchObject({
+      asPath: '/example?foo=bar',
+      pathname: '/example',
+      query: { foo: 'bar' },
+    });
+  });
+
 });
 ```
 
@@ -49,9 +77,12 @@ Currently supported features:
 - `router.query`
 - `router.locale`
 - `router.locales`
+- Works with `next/link` (see Jest notes)
 
 ## Not yet supported:
+
 PRs welcome!
+
 - `router.isReady`
 - `router.route`
 - `router.basePath`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Currently supported features:
 - `router.query`
 - `router.locale`
 - `router.locales`
+- `router.prefetch(url)` (does nothing)
 - Works with `next/link` (see Jest notes)
 
 ## Not yet supported:
@@ -89,5 +90,4 @@ PRs welcome!
 - `router.isFallback`
 - `router.back()`
 - `router.beforePopState(cb)`
-- `router.prefetch(url)`
 - `router.reload()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+      "integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.16.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
@@ -908,6 +918,74 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.2.0.tgz",
+      "integrity": "sha512-U8cTWENQPHO3QHvxBdfltJ+wC78ytMdg69ASvIdkGdQ/XRg4M9H2vvM3mHddxl+w/fM6NNqzGMwpQoh82v9VIA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.6",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.0.0.tgz",
+      "integrity": "sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-4.0.0.tgz",
@@ -918,6 +996,12 @@
         "@types/react": ">=16.9.0",
         "@types/react-test-renderer": ">=16.9.0"
       }
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.12",
@@ -1440,6 +1524,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arity-n": {
@@ -2422,6 +2516,12 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.4.tgz",
+      "integrity": "sha512-bY1K3/1Jy9D8Jd12eoeVahNXHLfHFb4TXWI8SQ4y8bImR9qDPmGITBAfmcffTkgUvbJn87r8dILOTWW5kZzkgA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3049,6 +3149,12 @@
           "dev": true
         }
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
+      "integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "1.1.0",
@@ -5432,6 +5538,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7185,6 +7297,29 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
     "react": ">=17.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^4.0.0",
     "@types/jest": "^26.0.20",
     "jest": "^26.6.3",
     "next": "^10.0.5",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
+    "react-dom": "^17.0.2",
     "react-test-renderer": "^17.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/router",
   "files": [

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -121,4 +121,8 @@ describe("MemoryRouter", () => {
     memoryRouter.locales = ["en", "fr"];
     expect(memoryRouter.locales).toEqual(["en", "fr"])
   });
+
+  it('prefetch should do nothing', async () => {
+    expect(await memoryRouter.prefetch()).toBeUndefined();
+  });
 });

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -70,7 +70,7 @@ export abstract class BaseRouter implements NextRouter {
   beforePopState = () => {
     throw new Error("NotImplemented");
   };
-  prefetch = () => {
+  prefetch = async (): Promise<void> => {
     throw new Error("NotImplemented");
   };
   reload = () => {
@@ -115,4 +115,6 @@ export class MemoryRouter extends BaseRouter {
 
     this.events.emit("routeChangeComplete");
   };
+
+  prefetch = async () => { /* Do nothing */ }
 }

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -7,9 +7,25 @@ import MockRouter from './router';
 jest.mock('next/dist/client/router', () => require('./router'));
 
 describe('next/link', () => {
-  it('should render a link', () => {
-    render(<NextLink href="/example">Example Link</NextLink>);
-    fireEvent.click(screen.getByText('Example Link'));
-    expect(MockRouter.asPath).toEqual('/example');
+  describe('clicking a link will mock navigate', () => {
+    it('to a href', () => {
+      render(<NextLink href="/example?foo=bar">Example Link</NextLink>);
+      fireEvent.click(screen.getByText('Example Link'));
+      expect(MockRouter).toMatchObject({
+        asPath: '/example?foo=bar',
+        pathname: '/example',
+        query: { foo: 'bar' },
+      });
+    });
+
+    it('to a URL object', () => {
+      render(<NextLink href={{ pathname: '/example', query: { foo: 'bar' } }}>Example Link</NextLink>);
+      fireEvent.click(screen.getByText('Example Link'));
+      expect(MockRouter).toMatchObject({
+        asPath: '/example?foo=bar',
+        pathname: '/example',
+        query: { foo: 'bar' },
+      });
+    });
   });
 });

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import NextLink from 'next/link';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import MockRouter from './router';
+
+jest.mock('next/dist/client/router', () => require('./router'));
+
+describe('next/link', () => {
+  it('should render a link', () => {
+    render(<NextLink href="/example">Example Link</NextLink>);
+    fireEvent.click(screen.getByText('Example Link'));
+    expect(MockRouter.asPath).toEqual('/example');
+  });
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
-import { MemoryRouter } from "./MemoryRouter";
+import { MemoryRouter } from './MemoryRouter';
 
 // Default export a singleton:
 const memoryRouter = new MemoryRouter();
@@ -8,17 +8,17 @@ export default memoryRouter;
 
 // Overrides the useRouter hook:
 export const useRouter = () => {
-  const [router, setRouter] = useState(memoryRouter);
+  const [ router, setRouter ] = useState(memoryRouter);
 
   useEffect(() => {
     const handleRouteChange = () => {
       // Clone the (mutable) memoryRouter, to ensure we trigger an update
       setRouter({ ...memoryRouter });
     };
-    memoryRouter.events.on("routeChangeComplete", handleRouteChange);
+    memoryRouter.events.on('routeChangeComplete', handleRouteChange);
 
     return () => {
-      memoryRouter.events.off("routeChangeComplete", handleRouteChange);
+      memoryRouter.events.off('routeChangeComplete', handleRouteChange);
     };
   }, []);
 


### PR DESCRIPTION
# What
Adds documentation for using `next-router-mock` with `next/link`

TODO:
- [x] Update README with `next/link` documentation
- [x] Add Unit tests