### PR TITLE
feat(MemoryRouter): Add routeChangeStart and pass router event arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,28 @@ jest.mock('next/router', () => require('next-router-mock'));
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 ```
 
-> Note: it's better to mock `next/dist/client/router` instead of  `next/router`, because both `next/router` and `next/link` depend directly on this nested path.  It's also perfectly fine to mock both.
+> Note: it's better to mock `next/dist/client/router` instead of  `next/router`, because both `next/router` and `next/link` depend directly on this nested path. It's also perfectly fine to mock both.
 
 Here's a full working example:
 
 ```js
 import router, { useRouter } from 'next/router';
+import NextLink from 'next/link';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('router', () => {
-  it('supports the `push` and `replace` methods', () => {
-    router.push('/foo?bar=baz');
+  it('supports the `push` and `replace` methods', async () => {
+    await router.push('/foo?bar=baz');
     expect(router).toMatchObject({
       asPath: '/foo?bar=baz',
       pathname: '/foo',
       query: { bar: 'baz' },
     });
   });
-  it('supports url object routes too', () => {
-    router.push({
+  it('supports url object routes too', async () => {
+    await router.push({
       pathname: '/foo/[id]',
       query: { id: '123', bar: 'baz' },
     });
@@ -52,13 +54,15 @@ describe('router', () => {
     });
   });
 
-  it('next/link can be tested too', () => {
+  it('next/link can be tested too', async () => {
     render(<NextLink href="/example?foo=bar">Example Link</NextLink>);
     fireEvent.click(screen.getByText('Example Link'));
-    expect(router).toMatchObject({
-      asPath: '/example?foo=bar',
-      pathname: '/example',
-      query: { foo: 'bar' },
+    await waitFor(() => {
+      expect(router).toMatchObject({
+        asPath: '/example?foo=bar',
+        pathname: '/example',
+        query: { foo: 'bar' },
+      });
     });
   });
 
@@ -70,8 +74,8 @@ describe('router', () => {
 Currently supported features:
 
 - `useRouter()`
-- `router.push(url)`
-- `router.replace(url)`
+- `router.push(url, as, options)`
+- `router.replace(url, as, options)`
 - `router.pathname`
 - `router.asPath`
 - `router.query`
@@ -79,6 +83,9 @@ Currently supported features:
 - `router.locales`
 - `router.prefetch(url)` (does nothing)
 - Works with `next/link` (see Jest notes)
+- `router.events` supports:
+  - `routeChangeStart(url, { shallow })`
+  - `routeChangeComplete(url, { shallow })`
 
 ## Not yet supported:
 
@@ -91,3 +98,9 @@ PRs welcome!
 - `router.back()`
 - `router.beforePopState(cb)`
 - `router.reload()`
+- `router.events` not yet supported: 
+  - `routeChangeError`
+  - `beforeHistoryChange`
+  - `hashChangeStart`
+  - `hashChangeComplete`
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -5745,11 +5745,6 @@
         "through2": "^2.0.0"
       }
     },
-    "mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,5 @@
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
   },
-  "dependencies": {
-    "mitt": "^3.0.0"
-  }
+  "dependencies": {}
 }

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -30,16 +30,37 @@ describe("MemoryRouter", () => {
       },
     });
   });
+
+  it("pushing should trigger the routeChangeStart event", () => {
+    const routeChangeStart = jest.fn();
+    memoryRouter.events.on("routeChangeStart", routeChangeStart);
+
+    memoryRouter.push(`/one`);
+    expect(routeChangeStart).toHaveBeenCalledTimes(1);
+    expect(routeChangeStart).toHaveBeenCalledWith('/one', { shallow: false });
+    memoryRouter.push(`/one/two`);
+    expect(routeChangeStart).toHaveBeenCalledTimes(2);
+    expect(routeChangeStart).toHaveBeenCalledWith('/one/two', { shallow: false });
+    memoryRouter.push({ pathname: `/one/two/three` });
+    expect(routeChangeStart).toHaveBeenCalledTimes(3);
+    expect(routeChangeStart).toHaveBeenCalledWith('/one/two/three', { shallow: false });
+
+    memoryRouter.events.off("routeChangeStart", routeChangeStart);
+  });
+
   it("pushing should trigger the routeChangeComplete event", () => {
     const routeChangeComplete = jest.fn();
     memoryRouter.events.on("routeChangeComplete", routeChangeComplete);
 
     memoryRouter.push(`/one`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(1);
+    expect(routeChangeComplete).toHaveBeenCalledWith('/one', { shallow: false });
     memoryRouter.push(`/one/two`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(2);
+    expect(routeChangeComplete).toHaveBeenCalledWith('/one/two', { shallow: false });
     memoryRouter.push({ pathname: `/one/two/three` });
     expect(routeChangeComplete).toHaveBeenCalledTimes(3);
+    expect(routeChangeComplete).toHaveBeenCalledWith('/one/two/three', { shallow: false });
 
     memoryRouter.events.off("routeChangeComplete", routeChangeComplete);
   });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -3,13 +3,13 @@ import { MemoryRouter } from "./MemoryRouter";
 describe("MemoryRouter", () => {
   const memoryRouter = new MemoryRouter();
 
-  it("should start empty", () => {
+  it("should start empty", async () => {
     expect(memoryRouter).toMatchObject({
       asPath: "",
       pathname: "",
       query: {},
       locale: undefined,
-    })
+    });
   });
   it("pushing URLs should update the route", async () => {
     await memoryRouter.push(`/one/two/three`);
@@ -18,10 +18,10 @@ describe("MemoryRouter", () => {
       asPath: "/one/two/three",
       pathname: "/one/two/three",
       query: {},
-    })
+    });
 
     await memoryRouter.push(`/one/two/three?four=4&five=`);
-    
+
     expect(memoryRouter).toMatchObject({
       asPath: "/one/two/three?four=4&five=",
       pathname: "/one/two/three",
@@ -38,13 +38,17 @@ describe("MemoryRouter", () => {
 
     await memoryRouter.push(`/one`);
     expect(routeChangeStart).toHaveBeenCalledTimes(1);
-    expect(routeChangeStart).toHaveBeenCalledWith('/one', { shallow: false });
+    expect(routeChangeStart).toHaveBeenCalledWith("/one", { shallow: false });
     await memoryRouter.push(`/one/two`);
     expect(routeChangeStart).toHaveBeenCalledTimes(2);
-    expect(routeChangeStart).toHaveBeenCalledWith('/one/two', { shallow: false });
+    expect(routeChangeStart).toHaveBeenCalledWith("/one/two", {
+      shallow: false,
+    });
     await memoryRouter.push({ pathname: `/one/two/three` });
     expect(routeChangeStart).toHaveBeenCalledTimes(3);
-    expect(routeChangeStart).toHaveBeenCalledWith('/one/two/three', { shallow: false });
+    expect(routeChangeStart).toHaveBeenCalledWith("/one/two/three", {
+      shallow: false,
+    });
 
     memoryRouter.events.off("routeChangeStart", routeChangeStart);
   });
@@ -55,96 +59,105 @@ describe("MemoryRouter", () => {
 
     await memoryRouter.push(`/one`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(1);
-    expect(routeChangeComplete).toHaveBeenCalledWith('/one', { shallow: false });
+    expect(routeChangeComplete).toHaveBeenCalledWith("/one", {
+      shallow: false,
+    });
     await memoryRouter.push(`/one/two`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(2);
-    expect(routeChangeComplete).toHaveBeenCalledWith('/one/two', { shallow: false });
+    expect(routeChangeComplete).toHaveBeenCalledWith("/one/two", {
+      shallow: false,
+    });
     await memoryRouter.push({ pathname: `/one/two/three` });
     expect(routeChangeComplete).toHaveBeenCalledTimes(3);
-    expect(routeChangeComplete).toHaveBeenCalledWith('/one/two/three', { shallow: false });
+    expect(routeChangeComplete).toHaveBeenCalledWith("/one/two/three", {
+      shallow: false,
+    });
 
     memoryRouter.events.off("routeChangeComplete", routeChangeComplete);
   });
 
-  it("pushing UrlObjects should update the route", () => {
-    memoryRouter.push({ pathname: "/one" });
+  it("pushing UrlObjects should update the route", async () => {
+    await memoryRouter.push({ pathname: "/one" });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one",
-        pathname: "/one",
-        query: {},
+      asPath: "/one",
+      pathname: "/one",
+      query: {},
     });
 
-    memoryRouter.push({
+    await memoryRouter.push({
       pathname: "/one/two/three",
       query: { four: "4", five: "" },
     });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one/two/three?four=4&five=",
-        pathname: "/one/two/three",
-        query: {
-          five: "",
-          four: "4",
-        },
-      });
+      asPath: "/one/two/three?four=4&five=",
+      pathname: "/one/two/three",
+      query: {
+        five: "",
+        four: "4",
+      },
+    });
   });
-  it("pushing UrlObjects should inject slugs", () => {
-    memoryRouter.push({ pathname: "/one/[id]", query: { id: "two" } });
+  it("pushing UrlObjects should inject slugs", async () => {
+    await memoryRouter.push({ pathname: "/one/[id]", query: { id: "two" } });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one/two",
-        pathname: "/one/[id]",
-        query: {
-          id: "two",
-        }
+      asPath: "/one/two",
+      pathname: "/one/[id]",
+      query: {
+        id: "two",
+      },
     });
 
-    memoryRouter.push({ pathname: "/one/[id]/three", query: { id: "two" } });
+    await memoryRouter.push({
+      pathname: "/one/[id]/three",
+      query: { id: "two" },
+    });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one/two/three",
-        pathname: "/one/[id]/three",
-        query: {
-          id: "two",
-        },
+      asPath: "/one/two/three",
+      pathname: "/one/[id]/three",
+      query: {
+        id: "two",
+      },
     });
 
-    memoryRouter.push({
+    await memoryRouter.push({
       pathname: "/one/[id]/three",
       query: { id: "two", four: "4" },
     });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one/two/three?four=4",
-        pathname: "/one/[id]/three",
-        query:  {
-          four: "4",
-          id: "two",
-        },
+      asPath: "/one/two/three?four=4",
+      pathname: "/one/[id]/three",
+      query: {
+        four: "4",
+        id: "two",
+      },
     });
-    memoryRouter.push({
+    await memoryRouter.push({
       pathname: "/one/[id]/three/[four]",
       query: { id: "two", four: "4" },
     });
     expect(memoryRouter).toMatchObject({
-        asPath: "/one/two/three/4",
-        pathname: "/one/[id]/three/[four]",
-        query: {
-          four: "4",
-          id: "two",
-        },
+      asPath: "/one/two/three/4",
+      pathname: "/one/[id]/three/[four]",
+      query: {
+        four: "4",
+        id: "two",
+      },
     });
   });
-  it("push the locale", () => {
-    memoryRouter.push("/", undefined, { locale: "en" });
+  it("push the locale", async () => {
+    await memoryRouter.push("/", undefined, { locale: "en" });
     expect(memoryRouter).toMatchObject({
-        locale: "en",
+      locale: "en",
     });
-  })
-
-  it('should support the locales property', () => {
-    expect(memoryRouter.locales).toEqual([ ]);
-    memoryRouter.locales = ["en", "fr"];
-    expect(memoryRouter.locales).toEqual(["en", "fr"])
   });
 
-  it('prefetch should do nothing', async () => {
+  it("should support the locales property", async () => {
+    expect(memoryRouter.locales).toEqual([]);
+    memoryRouter.locales = ["en", "fr"];
+    expect(memoryRouter.locales).toEqual(["en", "fr"]);
+  });
+
+  it("prefetch should do nothing", async () => {
     expect(await memoryRouter.prefetch()).toBeUndefined();
   });
 });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -11,8 +11,8 @@ describe("MemoryRouter", () => {
       locale: undefined,
     })
   });
-  it("pushing URLs should update the route", () => {
-    memoryRouter.push(`/one/two/three`);
+  it("pushing URLs should update the route", async () => {
+    await memoryRouter.push(`/one/two/three`);
 
     expect(memoryRouter).toMatchObject({
       asPath: "/one/two/three",
@@ -20,7 +20,8 @@ describe("MemoryRouter", () => {
       query: {},
     })
 
-    memoryRouter.push(`/one/two/three?four=4&five=`);
+    await memoryRouter.push(`/one/two/three?four=4&five=`);
+    
     expect(memoryRouter).toMatchObject({
       asPath: "/one/two/three?four=4&five=",
       pathname: "/one/two/three",
@@ -31,34 +32,34 @@ describe("MemoryRouter", () => {
     });
   });
 
-  it("pushing should trigger the routeChangeStart event", () => {
+  it("pushing should trigger the routeChangeStart event", async () => {
     const routeChangeStart = jest.fn();
     memoryRouter.events.on("routeChangeStart", routeChangeStart);
 
-    memoryRouter.push(`/one`);
+    await memoryRouter.push(`/one`);
     expect(routeChangeStart).toHaveBeenCalledTimes(1);
     expect(routeChangeStart).toHaveBeenCalledWith('/one', { shallow: false });
-    memoryRouter.push(`/one/two`);
+    await memoryRouter.push(`/one/two`);
     expect(routeChangeStart).toHaveBeenCalledTimes(2);
     expect(routeChangeStart).toHaveBeenCalledWith('/one/two', { shallow: false });
-    memoryRouter.push({ pathname: `/one/two/three` });
+    await memoryRouter.push({ pathname: `/one/two/three` });
     expect(routeChangeStart).toHaveBeenCalledTimes(3);
     expect(routeChangeStart).toHaveBeenCalledWith('/one/two/three', { shallow: false });
 
     memoryRouter.events.off("routeChangeStart", routeChangeStart);
   });
 
-  it("pushing should trigger the routeChangeComplete event", () => {
+  it("pushing should trigger the routeChangeComplete event", async () => {
     const routeChangeComplete = jest.fn();
     memoryRouter.events.on("routeChangeComplete", routeChangeComplete);
 
-    memoryRouter.push(`/one`);
+    await memoryRouter.push(`/one`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(1);
     expect(routeChangeComplete).toHaveBeenCalledWith('/one', { shallow: false });
-    memoryRouter.push(`/one/two`);
+    await memoryRouter.push(`/one/two`);
     expect(routeChangeComplete).toHaveBeenCalledTimes(2);
     expect(routeChangeComplete).toHaveBeenCalledWith('/one/two', { shallow: false });
-    memoryRouter.push({ pathname: `/one/two/three` });
+    await memoryRouter.push({ pathname: `/one/two/three` });
     expect(routeChangeComplete).toHaveBeenCalledTimes(3);
     expect(routeChangeComplete).toHaveBeenCalledWith('/one/two/three', { shallow: false });
 

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -91,16 +91,12 @@ export abstract class BaseRouter implements NextRouter {
  * TODO: Implement more methods!
  */
 export class MemoryRouter extends BaseRouter {
-  push = async (url: Url, as?: Url, options?: TransitionOptions) => {
-    this.setMemoryRoute(url, as, options);
-
-    return true;
+  push = (url: Url, as?: Url, options?: TransitionOptions) => {
+    return this.setMemoryRoute(url, as, options);
   };
 
-  replace = async (url: Url) => {
-    this.setMemoryRoute(url);
-
-    return true;
+  replace = (url: Url) => {
+    return this.setMemoryRoute(url);
   };
 
   /**
@@ -119,8 +115,19 @@ export class MemoryRouter extends BaseRouter {
       this.locale = options.locale;
     }
 
-    this.events.emit("routeChangeStart", this.asPath, { shallow: false });
-    this.events.emit("routeChangeComplete", this.asPath, { shallow: false });
+    this.events.emit("routeChangeStart", this.asPath, {
+      shallow: options?.shallow ?? false,
+    });
+
+    // Schedule next event emit on next tick to allow for setState updates
+    return new Promise<boolean>((resolve) =>
+      setTimeout(() => {
+        this.events.emit("routeChangeComplete", this.asPath, {
+          shallow: options?.shallow ?? false,
+        });
+        resolve(true);
+      }, 0)
+    );
   };
 
   prefetch = async () => {

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -104,22 +104,24 @@ export class MemoryRouter extends BaseRouter {
     const urlObject = typeof url === "string" ? parseUrl(url, true) : url;
 
     const shallow = options?.shallow || false;
-    const asPath = getRouteAsPath(this.pathname, this.query);
-    
+    const pathname = urlObject.pathname || "";
+    const query = urlObject.query || {};
+    const asPath = getRouteAsPath(pathname, query);
+
     this.events.emit("routeChangeStart", asPath, { shallow });
-    
+
     // Simulate the async nature of this method
     await new Promise(resolve => setImmediate(resolve));
-    
-    this.pathname = urlObject.pathname || "";
-    this.query = urlObject.query || {};
+
+    this.pathname = pathname;
+    this.query = query;
     this.asPath = asPath;
     if (options?.locale) {
       this.locale = options.locale;
     }
-    
+
     this.events.emit("routeChangeComplete", this.asPath, { shallow });
-    
+
     return true;
   };
 

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -1,4 +1,4 @@
-import mitt from "mitt";
+import mitt, { MittEmitter } from "./lib/mitt";
 import { parse as parseUrl, UrlWithParsedQuery } from "url";
 import { stringify as stringifyQueryString, ParsedUrlQuery } from "querystring";
 
@@ -43,9 +43,7 @@ interface TransitionOptions {
   scroll?: boolean;
 }
 
-type SupportedEventTypes = {
-  routeChangeComplete: undefined;
-};
+type SupportedEventTypes = "routeChangeStart" | "routeChangeComplete";
 
 /**
  * A base implementation of NextRouter that does nothing; all methods throw.
@@ -58,11 +56,15 @@ export abstract class BaseRouter implements NextRouter {
   asPath = "";
   basePath = "";
   isFallback = false;
-  events = mitt<SupportedEventTypes>();
+  events: MittEmitter<SupportedEventTypes> = mitt();
   locale: string | undefined = undefined;
   locales: string[] = [];
 
-  push = async (url: Url, as?: Url, options?: TransitionOptions): Promise<boolean> => {
+  push = async (
+    url: Url,
+    as?: Url,
+    options?: TransitionOptions
+  ): Promise<boolean> => {
     throw new Error("NotImplemented");
   };
   replace = async (url: Url): Promise<boolean> => {
@@ -117,8 +119,11 @@ export class MemoryRouter extends BaseRouter {
       this.locale = options.locale;
     }
 
-    this.events.emit("routeChangeComplete");
+    this.events.emit("routeChangeStart", this.asPath, { shallow: false });
+    this.events.emit("routeChangeComplete", this.asPath, { shallow: false });
   };
 
-  prefetch = async () => { /* Do nothing */ }
+  prefetch = async () => {
+    /* Do nothing */
+  };
 }

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -60,7 +60,11 @@ export abstract class BaseRouter implements NextRouter {
   locale: string | undefined = undefined;
   locales: string[] = [];
 
-  push = async (url: Url, as?: Url, options?: TransitionOptions): Promise<boolean> => {
+  push = async (
+    url: Url,
+    as?: Url,
+    options?: TransitionOptions
+  ): Promise<boolean> => {
     throw new Error("NotImplemented");
   };
   replace = async (url: Url): Promise<boolean> => {
@@ -88,18 +92,26 @@ export abstract class BaseRouter implements NextRouter {
  */
 export class MemoryRouter extends BaseRouter {
   push = (url: Url, as?: Url, options?: TransitionOptions) => {
-    return this.setMemoryRoute(url, as, options);
+    return this._setCurrentUrl(url, as, options, true);
   };
 
-  replace = (url: Url) => {
-    return this.setMemoryRoute(url);
+  replace = (url: Url, as?: Url, options?: TransitionOptions) => {
+    return this._setCurrentUrl(url, as, options, true);
   };
 
   /**
-   * Sets the current route to the specified url.
-   * @param url - String or Url-like object
+   * Sets the current Memory route to the specified url, synchronously.
    */
-  setMemoryRoute = async (url: Url, as?: Url, options?: TransitionOptions) => {
+  public setCurrentUrl = (url: Url) => {
+    void this._setCurrentUrl(url); // (ignore the returned promise)
+  };
+
+  private _setCurrentUrl = async (
+    url: Url,
+    as?: Url,
+    options?: TransitionOptions,
+    async?: boolean
+  ) => {
     // Parse the URL if needed:
     const urlObject = typeof url === "string" ? parseUrl(url, true) : url;
 
@@ -111,7 +123,7 @@ export class MemoryRouter extends BaseRouter {
     this.events.emit("routeChangeStart", asPath, { shallow });
 
     // Simulate the async nature of this method
-    await new Promise(resolve => setImmediate(resolve));
+    if (async) await new Promise((resolve) => setImmediate(resolve));
 
     this.pathname = pathname;
     this.query = query;

--- a/src/lib/mitt/index.ts
+++ b/src/lib/mitt/index.ts
@@ -1,0 +1,42 @@
+/*
+MIT License
+Copyright (c) Jason Miller (https://jasonformat.com/)
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// This file is based on https://github.com/developit/mitt/blob/v1.1.3/src/index.js
+// It's been edited for the needs of this script
+// See the LICENSE at the top of the file
+
+type Handler = (...evts: any[]) => void
+
+export type MittEmitter<T> = {
+  on(type: T, handler: Handler): void
+  off(type: T, handler: Handler): void
+  emit(type: T, ...evts: any[]): void
+}
+
+export default function mitt(): MittEmitter<string> {
+  const all: { [s: string]: Handler[] } = Object.create(null)
+
+  return {
+    on(type: string, handler: Handler) {
+      ;(all[type] || (all[type] = [])).push(handler)
+    },
+
+    off(type: string, handler: Handler) {
+      if (all[type]) {
+        all[type].splice(all[type].indexOf(handler) >>> 0, 1)
+      }
+    },
+
+    emit(type: string, ...evts: any[]) {
+      // eslint-disable-next-line array-callback-return
+      ;(all[type] || []).slice().map((handler: Handler) => {
+        handler(...evts)
+      })
+    },
+  }
+}

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -1,30 +1,38 @@
-import React from 'react';
-import NextLink from 'next/link';
-import { fireEvent, render, screen } from '@testing-library/react';
+import React from "react";
+import NextLink from "next/link";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import MockRouter from './router';
+import MockRouter from "./router";
 
-jest.mock('next/dist/client/router', () => require('./router'));
+jest.mock("next/dist/client/router", () => require("./router"));
 
-describe('next/link', () => {
-  describe('clicking a link will mock navigate', () => {
-    it('to a href', () => {
+describe("next/link", () => {
+  describe("clicking a link will mock navigate", () => {
+    it("to a href", async () => {
       render(<NextLink href="/example?foo=bar">Example Link</NextLink>);
-      fireEvent.click(screen.getByText('Example Link'));
-      expect(MockRouter).toMatchObject({
-        asPath: '/example?foo=bar',
-        pathname: '/example',
-        query: { foo: 'bar' },
+      fireEvent.click(screen.getByText("Example Link"));
+      await waitFor(() => {
+        expect(MockRouter).toMatchObject({
+          asPath: "/example?foo=bar",
+          pathname: "/example",
+          query: { foo: "bar" },
+        });
       });
     });
 
-    it('to a URL object', () => {
-      render(<NextLink href={{ pathname: '/example', query: { foo: 'bar' } }}>Example Link</NextLink>);
-      fireEvent.click(screen.getByText('Example Link'));
-      expect(MockRouter).toMatchObject({
-        asPath: '/example?foo=bar',
-        pathname: '/example',
-        query: { foo: 'bar' },
+    it("to a URL object", async () => {
+      render(
+        <NextLink href={{ pathname: "/example", query: { foo: "bar" } }}>
+          Example Link
+        </NextLink>
+      );
+      fireEvent.click(screen.getByText("Example Link"));
+      await waitFor(() => {
+        expect(MockRouter).toMatchObject({
+          asPath: "/example?foo=bar",
+          pathname: "/example",
+          query: { foo: "bar" },
+        });
       });
     });
   });

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -14,13 +14,13 @@ describe("router", () => {
       expect(result.current).toBe(router);
     });
 
-    it('"push" will cause a rerender with the new route', () => {
+    it('"push" will cause a rerender with the new route', async () => {
       const { result, rerender } = renderHook(() => useRouter());
 
       expect(result.current).toBe(router);
 
-      act(() => {
-        result.current.push("/foo?bar=baz");
+      await act(async () => {
+        await result.current.push("/foo?bar=baz");
       });
 
       expect(result.current).not.toBe(router);
@@ -37,7 +37,7 @@ describe("router", () => {
       expect(result.current.locales).toEqual([]);
 
       act(() => {
-        result.current.push("/", undefined, { locale: "en" })
+        result.current.push("/", undefined, { locale: "en" });
       });
       expect(result.current.locale).toBe("en");
     });

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import router, { useRouter } from "./router";
 import { MemoryRouter } from "./MemoryRouter";
+import { useEffect, useRef } from "react";
 
 describe("router", () => {
   it("should export a default router", () => {
@@ -14,7 +15,51 @@ describe("router", () => {
       expect(result.current).toBe(router);
     });
 
-    it('"push" will cause a rerender with the new route', async () => {
+    it("will allow capturing previous route values in hooks with routing events", async () => {
+      const mockOnRouteChange = jest.fn();
+
+      // see: https://github.com/streamich/react-use/blob/master/src/usePrevious.ts
+      const usePrevious = function <T>(value: T): T | undefined {
+        const previous = useRef<T>();
+
+        useEffect(() => {
+          previous.current = value;
+        });
+
+        return previous.current;
+      };
+
+      const useRouterWithPrevious = () => {
+        const { asPath, events } = useRouter();
+        const previousAsPath = usePrevious(asPath);
+
+        useEffect(() => {
+          const handleRouteChangeComplete = (nextUrl: string) =>
+            mockOnRouteChange(previousAsPath, nextUrl);
+
+          events.on("routeChangeComplete", handleRouteChangeComplete);
+
+          return () => {
+            events.off("routeChangeComplete", handleRouteChangeComplete);
+          };
+        }, [previousAsPath, events]);
+
+        return router;
+      };
+
+      // Push initial state
+      await router.push('/foo');
+
+      const { result } = renderHook(() => useRouterWithPrevious());
+
+      await act(async () => {
+        await result.current.push("/foo?bar=baz");
+      });
+
+      expect(mockOnRouteChange).toHaveBeenCalledWith("/foo", "/foo?bar=baz");
+    });
+
+    it('"push" will cause a rerender on routeChangeComplete with the new route', async () => {
       const { result } = renderHook(() => useRouter());
 
       expect(result.current).toBe(router);

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -8,14 +8,14 @@ describe("router", () => {
   });
 
   describe("useRouter", () => {
-    it("the useRouter hook should return the same instance of the router", () => {
+    it("the useRouter hook should return the same instance of the router", async () => {
       const { result } = renderHook(() => useRouter());
 
       expect(result.current).toBe(router);
     });
 
     it('"push" will cause a rerender with the new route', async () => {
-      const { result, rerender } = renderHook(() => useRouter());
+      const { result } = renderHook(() => useRouter());
 
       expect(result.current).toBe(router);
 
@@ -31,13 +31,13 @@ describe("router", () => {
       });
     });
 
-    it("support the locales and locale properties", () => {
+    it("support the locales and locale properties", async () => {
       const { result } = renderHook(() => useRouter());
       expect(result.current.locale).toBe(undefined);
       expect(result.current.locales).toEqual([]);
 
-      act(() => {
-        result.current.push("/", undefined, { locale: "en" });
+      await act(async () => {
+        await result.current.push("/", undefined, { locale: "en" });
       });
       expect(result.current.locale).toBe("en");
     });

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -35,8 +35,8 @@ describe("router", () => {
         return [previousAsPath, asPath];
       };
 
-      // Push initial state
-      await router.push('/foo');
+      // Set initial state:
+      router.setCurrentUrl("/foo");
 
       const { result } = renderHook(() => useRouterWithPrevious());
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
-import { MemoryRouter } from './MemoryRouter';
+import { MemoryRouter } from "./MemoryRouter";
 
 // Default export a singleton:
 const memoryRouter = new MemoryRouter();
@@ -8,17 +8,19 @@ export default memoryRouter;
 
 // Overrides the useRouter hook:
 export const useRouter = () => {
-  const [ router, setRouter ] = useState(memoryRouter);
+  const [router, setRouter] = useState(memoryRouter);
 
   useEffect(() => {
     const handleRouteChange = () => {
       // Clone the (mutable) memoryRouter, to ensure we trigger an update
       setRouter({ ...memoryRouter });
     };
-    memoryRouter.events.on('routeChangeComplete', handleRouteChange);
+    memoryRouter.events.on("routeChangeStart", handleRouteChange);
+    memoryRouter.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
-      memoryRouter.events.off('routeChangeComplete', handleRouteChange);
+      memoryRouter.events.off("routeChangeStart", handleRouteChange);
+      memoryRouter.events.off("routeChangeComplete", handleRouteChange);
     };
   }, []);
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,15 +9,23 @@ export default memoryRouter;
 // Overrides the useRouter hook:
 export const useRouter = () => {
   const [router, setRouter] = useState(memoryRouter);
+  const [, rerender] = useState<object>();
 
   useEffect(() => {
     const handleRouteChange = () => {
       // Clone the (mutable) memoryRouter, to ensure we trigger an update
       setRouter({ ...memoryRouter });
     };
+
+    const handleRouteStart = () => {
+      rerender({});
+    };
+
+    memoryRouter.events.on("routeChangeStart", handleRouteStart);
     memoryRouter.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
+      memoryRouter.events.off("routeChangeStart", handleRouteStart);
       memoryRouter.events.off("routeChangeComplete", handleRouteChange);
     };
   }, []);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -15,11 +15,9 @@ export const useRouter = () => {
       // Clone the (mutable) memoryRouter, to ensure we trigger an update
       setRouter({ ...memoryRouter });
     };
-    memoryRouter.events.on("routeChangeStart", handleRouteChange);
     memoryRouter.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
-      memoryRouter.events.off("routeChangeStart", handleRouteChange);
       memoryRouter.events.off("routeChangeComplete", handleRouteChange);
     };
   }, []);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,7 +9,6 @@ export default memoryRouter;
 // Overrides the useRouter hook:
 export const useRouter = () => {
   const [router, setRouter] = useState(memoryRouter);
-  const [, rerender] = useState<object>();
 
   useEffect(() => {
     const handleRouteChange = () => {
@@ -17,15 +16,9 @@ export const useRouter = () => {
       setRouter({ ...memoryRouter });
     };
 
-    const handleRouteStart = () => {
-      rerender({});
-    };
-
-    memoryRouter.events.on("routeChangeStart", handleRouteStart);
     memoryRouter.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
-      memoryRouter.events.off("routeChangeStart", handleRouteStart);
       memoryRouter.events.off("routeChangeComplete", handleRouteChange);
     };
   }, []);


### PR DESCRIPTION
## Changes

- Add support for `routeChangeStart`
- Make `push` async and emit `routeChangeComplete` async
- Use [Next.js `mitt` implementation](https://github.com/vercel/next.js/blob/5544adc481f8821567e947a6e6d51d9d68ebd367/packages/next/shared/lib/mitt.ts#L25) which supports passing an array of event objects
- Pass `url` and `{ shallow }` event arguments

Thanks for this library, it TOTALLY simplified all my router-based mocking and tests. I just needed the other event and to ensure the right URLs are being passed around.