### PR TITLE
🐛 Fix/router becomes stale

### DIFF
--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -87,10 +87,6 @@ export abstract class BaseRouter implements NextRouter {
  * TODO: Implement more methods!
  */
 export class MemoryRouter extends BaseRouter {
-  static clone(original: MemoryRouter): MemoryRouter {
-    return Object.assign(new MemoryRouter(), original);
-  }
-
   /**
    *
    */
@@ -128,7 +124,7 @@ export class MemoryRouter extends BaseRouter {
     this.events.emit("routeChangeStart", asPath, { shallow });
 
     // Simulate the async nature of this method
-    if (async) await new Promise((resolve) => setImmediate(resolve));
+    if (async) await new Promise((resolve) => setTimeout(resolve, 0));
 
     this.pathname = pathname;
     this.query = query;

--- a/src/useMemoryRouter.tsx
+++ b/src/useMemoryRouter.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 
 import { MemoryRouter } from "./MemoryRouter";
 
-export const useMemoryRouter = (initialRouter: MemoryRouter) => {
-  const [router, setRouter] = useState(initialRouter);
+export const useMemoryRouter = (router: MemoryRouter) => {
+  // const [router, setRouter] = useState(initialRouter);
+  const [, force] = useReducer((x) => !x, false);
 
   useEffect(() => {
-    const handleRouteChange = () => {
-      // Clone the (mutable) memoryRouter, to ensure we trigger an update
-      setRouter((r) => MemoryRouter.clone(r));
-    };
+    const handleRouteChange = () => force();
 
     router.events.on("routeChangeComplete", handleRouteChange);
 
@@ -18,7 +16,7 @@ export const useMemoryRouter = (initialRouter: MemoryRouter) => {
     };
   }, [
     // Events is a singleton, shared by all clones, so this should never actually change:
-    router.events,
+    router.events
   ]);
 
   return router;


### PR DESCRIPTION
# Bug Report and Fix

## Description

On this branch checkout this commit ccf6a4f - it features test cases modified to take in more than 2 route changes. Namely,  anything more than two calls on `router.push`, fails to be updated.

From debugging with `node --inspect-brk node_modules/.bin/jest useMemoryRouter` I noticed that calls to `setRouter` on `useMemoryRouter` had an stale closure over the `r`, router, argument, always stuck at whatever was passed the second time. Since this pretty much failed after 2 calls to push, I do not know if its just lagging one step behind or permanently stuck at the second call. At any rate, this is broken behavior.

I also managed to check that 0.2.4 does not have this bug. It has been introduced in 0.3.0. 

I also managed to reproduce this bug twice. First on my current main project and second on a `create next-app` template, document further below.

## Fix

The second commit 9320dfa on this PR contains the fixes.

On router change completed, I do a force render on the `useMemoryRouter` hook, with a useReducer quick toggle.

I also got rid of `setImmediate`, for a `setTimeout(fn,0)`, which is more standard and does run on "browser-side" tests.

Since it's not used anymore the cloning has been removed.

## Demo

A quick demo can be generated with: 

```
yarn create next-app --example with-jest with-jest-app && yarn add next-router-mock
```

```jsx
// pages/index.js
import { useRouter } from "next/router";

const Home = () => {
  const router = useRouter();

  return (
    <main>
      <h1>{router.query.claim}</h1>
    </main>
  );
};

export default Home;


// index.test.js
/**
 * @jest-environment jsdom
 */

import React from "react";
import { render, screen } from "@testing-library/react";
import Home from "../pages/index";
import router from "next/router";
import { act } from "react-dom/test-utils";

jest.mock("next/router", () => require("next-router-mock/dist/async"));
// or this:
jest.mock("next/dist/client/router", () =>
  require("next-router-mock/dist/async")
);

const fakeImmediate = (fn, ...args) => {
  process.nextTick(() => fn(...args)); // or postMessage + listener
  return;
};

// this was necessary before this PR
global.setImmediate = global.setImmediate || fakeImmediate;

describe("Home", () => {
  it("renders a heading", async () => {
    await act(async () => {
      await router.push("/?claim=next");
    });

    render(<Home />);

    const first = screen.getByText("next");
    expect(first).toBeInTheDocument();

    await act(async () => {
      await router.push("/?claim=mock");
    });

    const second = screen.getByText("mock");
    expect(second).toBeInTheDocument();
    // at this point the router has gone stale, so the test fails on the next assertion.


    await act(async () => {
      await router.push("/?claim=router");
    });

    const third = screen.getByText("router");
    expect(third).toBeInTheDocument();
  });
});

```