### PR TITLE
fix: Use setTimeout instead of setImmediate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/index",
   "files": [

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -128,7 +128,7 @@ export class MemoryRouter extends BaseRouter {
     this.events.emit("routeChangeStart", asPath, { shallow });
 
     // Simulate the async nature of this method
-    if (async) await new Promise((resolve) => setImmediate(resolve));
+    if (async) await new Promise((resolve) => setTimeout(resolve, 0));
 
     this.pathname = pathname;
     this.query = query;


### PR DESCRIPTION
My bad, I didn't realize `setImmediate` is a Node-only feature!  
This fix allows the lib to be used in a real browser.