### PR TITLE
feature(next-v11): removed auto-detect

### DIFF
--- a/MemoryRouterProvider/index.js
+++ b/MemoryRouterProvider/index.js
@@ -1,7 +1,0 @@
-// Automatically determine which Next version to export:
-const nextVersion = require("next/package.json")
-  .version.split(".")
-  .map((d) => Number(d));
-const isNextV11_1 = nextVersion[0] >= 11 && nextVersion[1] >= 1;
-
-module.exports = isNextV11_1 ? require("./next-11") : require("./next-10");

--- a/MemoryRouterProvider/next-10.js
+++ b/MemoryRouterProvider/next-10.js
@@ -1,1 +1,0 @@
-module.exports = require("../dist/MemoryRouterProvider/MemoryRouterProvider-10");

--- a/MemoryRouterProvider/next-10/package.json
+++ b/MemoryRouterProvider/next-10/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../../dist/MemoryRouterProvider/MemoryRouterProvider-10"
+}

--- a/MemoryRouterProvider/next-11.js
+++ b/MemoryRouterProvider/next-11.js
@@ -1,1 +1,0 @@
-module.exports = require("../dist/MemoryRouterProvider/MemoryRouterProvider-11.1");

--- a/MemoryRouterProvider/package.json
+++ b/MemoryRouterProvider/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/MemoryRouterProvider/MemoryRouterProvider-11.1"
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Tested with NextJS v10 and v11.
 
 Install via NPM: `npm install --save-dev next-router-mock`
 
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quick Start](#quick-start)
+- [Usage with Jest](#usage-with-jest)
+- [Usage with Storybook](#usage-with-storybook)
+    - [`MemoryRouterProvider` compatibility with Next 10](#memoryrouterprovider-compatibility-with-next-10)
+- [Sync vs Async](#sync-vs-async)
+- [Supported Features](#supported-features)
+  - [Not yet supported](#not-yet-supported)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Quick Start
 
 For unit tests, the `next-router-mock` module can be used as a drop-in replacement for `next/router`. It exports both a default (singleton) router and
@@ -23,22 +38,6 @@ For Storybook, you can use `<MemoryRouterProvider>` to wrap your stories.  Examp
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 addDecorator(Story => <MemoryRouterProvider><Story /></MemoryRouterProvider>);
 ```
-
-
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Usage with Jest](#usage-with-jest)
-- [Usage with Storybook](#usage-with-storybook)
-    - [`MemoryRouterProvider` compatibility:](#memoryrouterprovider-compatibility)
-- [Sync vs Async](#sync-vs-async)
-- [Supported Features](#supported-features)
-  - [Not yet supported](#not-yet-supported)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 
 # Usage with Jest
 
@@ -156,16 +155,14 @@ export const ExampleStory = () => (
 );
 ```
 
-### `MemoryRouterProvider` compatibility:  
-The above `MemoryRouterProvider` has to import the `router-context` from Next, which is located in different locations depending on the Next version.  So it automatically detects the Next version.  
+### `MemoryRouterProvider` compatibility with Next 10
 
-If needed, you can explicitly import from any of these paths:  
+The above examples work with Next `v11.1.0` or higher.   
 
-| NextJS Version | Import Path |
-| ------------ | ----------- |
-| Auto-detect | `next-router-mock/MemoryRouterProvider` |
-| Next `>= 11.1.0` | `next-router-mock/MemoryRouterProvider/next-11` |
-| Next `10.* - 11.0.*` | `next-router-mock/MemoryRouterProvider/next-10` |
+If you are using Next `v10.*` or `v11.0.*`, simply use the following import instead:
+```js
+import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider/next-10';
+```
 
 # Sync vs Async
 

--- a/async/index.js
+++ b/async/index.js
@@ -1,1 +1,0 @@
-module.exports = require("../dist/async");

--- a/async/package.json
+++ b/async/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/async"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/index",
   "scripts": {


### PR DESCRIPTION
Removes auto-detect, which doesn't work with Storybook (because Webpack automatically imports both versions).
Also, use `package.json` top-level import paths, so that types are kept intact.
