### PR TITLE
Add query string to asPath in dynamic routing

### DIFF
--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -195,6 +195,24 @@ describe("MemoryRouter", () => {
             filter: "abc"
           }
         });
+        await memoryRouter.push({
+          pathname: "/one/two/[[...slug]]",
+          query: { slug: ["three", "four"] }
+        });
+        expect(memoryRouter).toMatchObject({
+          asPath: "/one/two/three/four",
+          pathname: "/one/two/[[...slug]]",
+          query: {}
+        });
+        await memoryRouter.push({
+          pathname: "/one/two/[[...slug]]",
+          query: {}
+        });
+        expect(memoryRouter).toMatchObject({
+          asPath: "/one/two",
+          pathname: "/one/two/[[...slug]]",
+          query: {}
+        });
       });
       it("push the locale", async () => {
         await memoryRouter.push("/", undefined, { locale: "en" });
@@ -319,6 +337,30 @@ describe("MemoryRouter", () => {
           pathname: "/entity/[id]",
           asPath: "/entity/100?filter=abc&max=1000",
           query: { id: "100", filter: "abc", max: "1000" }
+        });
+      });
+
+      it("will properly interpolate optional catch-all routes from the pathname", async () => {
+        memoryRouter.registerPaths(["/one/two/[[...slug]]"]);
+
+        await memoryRouter.push("/one/two/three/four");
+
+        expect(memoryRouter).toMatchObject({
+          pathname: "/one/two/[[...slug]]",
+          asPath: "/one/two/three/four",
+          query: { slug: ["three", "four"] }
+        });
+      });
+
+      it("will match route with optional catch-all ommitted", async () => {
+        memoryRouter.registerPaths(["/entity/[id]/[[...slug]]"]);
+
+        await memoryRouter.push("/entity/42");
+
+        expect(memoryRouter).toMatchObject({
+          pathname: "/entity/[id]/[[...slug]]",
+          asPath: "/entity/42",
+          query: { id: "42" }
         });
       });
     });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -183,6 +183,18 @@ describe("MemoryRouter", () => {
             id: "two",
           },
         });
+        await memoryRouter.push({
+          pathname: "/one/[...slug]",
+          query: { slug: ["two", "three", "four"], filter: "abc"}
+        });
+        expect(memoryRouter).toMatchObject({
+          asPath: "/one/two/three/four?filter=abc",
+          pathname: "/one/[...slug]",
+          query: {
+            slug: ["two", "three", "four"],
+            filter: "abc"
+          }
+        });
       });
       it("push the locale", async () => {
         await memoryRouter.push("/", undefined, { locale: "en" });
@@ -251,12 +263,14 @@ describe("MemoryRouter", () => {
       });
 
       it("when query param matches path param, path param will take precedence", async () => {
-        memoryRouter.registerPaths(["/entity/[id]"])
+        memoryRouter.registerPaths(["/entity/[id]"]);
 
-        await memoryRouter.push("/entity/100?id=500")
+        await memoryRouter.push("/entity/100?id=500");
 
         expect(memoryRouter).toMatchObject({
-          query: { id: "100" }
+          pathname: "/entity/[id]",
+          query: { id: "100" },
+          asPath: "/entity/100?id=500"
         });
       });
 
@@ -272,15 +286,39 @@ describe("MemoryRouter", () => {
         });
       });
 
-      it("will properly interpolate catch-all routes from the pathname", async () => {
-        memoryRouter.registerPaths(["/[...slug]"])
+      it ("when slug passed in pathname with additional query params, asPath should have query string", async () => {
+        memoryRouter.registerPaths(["/entity/[id]"]);
 
-        await memoryRouter.push({pathname: "/[...slug]", query: { slug : ["one", "two", "three"]}})
+        await memoryRouter.push({pathname: "/entity/[id]", query: { id: "42", filter: "abc"}});
+
+        expect(memoryRouter).toMatchObject({
+          pathname: "/entity/[id]",
+          asPath: "/entity/42?filter=abc",
+          query: { id: "42", filter: "abc"}
+        });
+      })
+
+      it("will properly interpolate catch-all routes from the pathname", async () => {
+        memoryRouter.registerPaths(["/[...slug]"]);
+
+        await memoryRouter.push({pathname: "/[...slug]", query: { slug : ["one", "two", "three"]}});
 
         expect(memoryRouter).toMatchObject({
           pathname: "/[...slug]",
           asPath: "/one/two/three",
           query: { slug: ["one", "two", "three"] }
+        });
+      });
+
+      it("with dynamic routes, will properly generate asPath when passed in query dictionary", async () => {
+        memoryRouter.registerPaths(["/entity/[id]"]);
+
+        await memoryRouter.push({pathname: "/entity/100", query: {filter: "abc", max: "1000"}})
+
+        expect(memoryRouter).toMatchObject({
+          pathname: "/entity/[id]",
+          asPath: "/entity/100?filter=abc&max=1000",
+          query: { id: "100", filter: "abc", max: "1000" }
         });
       });
     });

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -33,7 +33,6 @@ function getRouteAsPath(pathname: string, query: ParsedUrlQuery) {
 
 export type UrlObject = {
   pathname: UrlWithParsedQuery["pathname"];
-  path?: UrlWithParsedQuery["path"];
   query?: UrlWithParsedQuery["query"];
 };
 export type Url = string | UrlObject;

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -12,7 +12,7 @@ function getRouteAsPath(pathname: string, query: ParsedUrlQuery) {
   const remainingQuery = { ...query };
 
   // Replace slugs, and remove them from the `query`
-  let asPath = pathname.replace(/\[(.+?)]/g, ($0, slug: keyof ParsedUrlQuery) => {
+  let asPath = pathname.replace(/\[{1,2}(.+?)]{1,2}/g, ($0, slug: keyof ParsedUrlQuery) => {
     if (String(slug).startsWith("...")) slug = String(slug).replace("...", "")
 
     const value = remainingQuery[slug]!;
@@ -20,8 +20,11 @@ function getRouteAsPath(pathname: string, query: ParsedUrlQuery) {
     if (Array.isArray(value)) {
       return value.map(v => encodeURIComponent(v)).join("/")
     }
-    return encodeURIComponent(String(value));
+    return value !== undefined ? encodeURIComponent(String(value)) : "";
   });
+
+  // Remove any trailing slashes; this will occur if there is no match for a catch-all slug ([[...slug]])
+  asPath = asPath.replace(/\/$/, "");
 
   // Append remaining query as a querystring, if needed:
   const qs = stringifyQueryString(remainingQuery);

--- a/src/dynamic-routes/extensions-10.ts
+++ b/src/dynamic-routes/extensions-10.ts
@@ -3,7 +3,6 @@ import { getRouteMatcher, getRouteRegex, getSortedRoutes, isDynamicRoute } from 
 // @ts-ignore
 import { normalizePagePath } from "next/dist/next-server/server/normalize-page-path";
 // @ts-ignore
-import { interpolateAs } from "next/dist/next-server/lib/router/router";
 import {UrlObject, MemoryRouter} from "../MemoryRouter";
 import "./path-parser"
 
@@ -38,12 +37,10 @@ const createPathParserFromPaths = (paths: string[]) => {
     // a query dictionary will be provided, so instead of using the match we interpolate the route from
     // the provided query
     const parsedQuery = isDynamic ? url.query : (match ? match : {});
-    const asPath = isDynamic ? interpolateAs(pathname, pathname, url.query ?? {}).result : pathname
 
     return {
       pathname: matcher?.pathname ?? pathname,
       query: {...url.query, ...parsedQuery},
-      asPath: asPath
     }
   }
 }

--- a/src/dynamic-routes/extensions-11.1.ts
+++ b/src/dynamic-routes/extensions-11.1.ts
@@ -1,7 +1,6 @@
 import {UrlObject, MemoryRouter} from "../MemoryRouter";
 import {getRouteMatcher, getRouteRegex, getSortedRoutes, isDynamicRoute} from "next/dist/shared/lib/router/utils";
 import {normalizePagePath} from "next/dist/server/normalize-page-path";
-import {interpolateAs} from "next/dist/shared/lib/router/router";
 import "./path-parser"
 
 declare module "../MemoryRouter" {
@@ -33,12 +32,10 @@ const createPathParserFromPaths = (paths: string[]) => {
     // a query dictionary will be provided, so instead of using the match we interpolate the route from
     // the provided query
     const parsedQuery = isDynamic ? url.query : (match ? match : {});
-    const asPath = isDynamic ? interpolateAs(pathname, pathname, url.query ?? {}).result : pathname
 
     return {
       pathname: matcher?.pathname ?? pathname,
       query: {...url.query, ...parsedQuery},
-      asPath: asPath
     }
   }
 }

--- a/src/dynamic-routes/path-parser.ts
+++ b/src/dynamic-routes/path-parser.ts
@@ -1,12 +1,12 @@
-import {MemoryRouter, UrlObject, UrlObjectWithPath} from "../MemoryRouter";
+import {MemoryRouter, UrlObject} from "../MemoryRouter";
 
 declare module "../MemoryRouter" {
   interface MemoryRouter {
-    setPathParser(parser: (url: UrlObject) => UrlObjectWithPath): void
+    setPathParser(parser: (url: UrlObject) => UrlObject): void
   }
 }
 
-MemoryRouter.prototype.setPathParser = function(parser: (url: UrlObject) => UrlObjectWithPath) {
+MemoryRouter.prototype.setPathParser = function(parser: (url: UrlObject) => UrlObject) {
   this.pathParser = parser
 }
 


### PR DESCRIPTION
In writing tests for our project, a coworker and I stumbled across a bit of functionality that wasn't quite right with the new dynamic routes feature. Query strings were being dropped in the `asPath` property of the router.

It turns out that the best way to solve this was to add catch-all route handling to the `getRouteAsPath` function and use that across the board. Doing so means that we no longer need the additional composite type `UrlObjectWithPath`, so that was removed as well.