### PR TITLE
feature(events): add hashChangeStart and hashChangeComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Install via NPM: `npm install --save-dev next-router-mock`
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [`next-router-mock`](#next-router-mock)
 - [Quick Start](#quick-start)
 - [Usage with Jest](#usage-with-jest)
 - [Usage with Storybook](#usage-with-storybook)
     - [`MemoryRouterProvider` compatibility with Next 10](#memoryrouterprovider-compatibility-with-next-10)
+- [Dynamic Routes](#dynamic-routes)
 - [Sync vs Async](#sync-vs-async)
 - [Supported Features](#supported-features)
   - [Not yet supported](#not-yet-supported)
@@ -242,6 +244,4 @@ These fields just have default values; these methods do nothing.
 - `router.events` not implemented:
   - `routeChangeError`
   - `beforeHistoryChange`
-  - `hashChangeStart`
-  - `hashChangeComplete`
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ it('next/link can be tested too', async () => {
 - `router.events` supports:
   - `routeChangeStart(url, { shallow })`
   - `routeChangeComplete(url, { shallow })`
+  - `hashChangeStart(url, { shallow })`
+  - `hashChangeComplete(url, { shallow })`
 
 ## Not yet supported
 

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -43,13 +43,19 @@ describe("MemoryRouter", () => {
       describe("routeChangeStart and routeChangeComplete events", () => {
         const routeChangeStart = jest.fn();
         const routeChangeComplete = jest.fn();
+        const hashChangeStart = jest.fn();
+        const hashChangeComplete = jest.fn();
         beforeAll(() => {
           memoryRouter.events.on("routeChangeStart", routeChangeStart);
           memoryRouter.events.on("routeChangeComplete", routeChangeComplete);
+          memoryRouter.events.on("hashChangeStart", hashChangeStart);
+          memoryRouter.events.on("hashChangeComplete", hashChangeComplete);
         });
         afterAll(() => {
           memoryRouter.events.off("routeChangeStart", routeChangeStart);
           memoryRouter.events.off("routeChangeComplete", routeChangeComplete);
+          memoryRouter.events.off("hashChangeStart", hashChangeStart);
+          memoryRouter.events.off("hashChangeComplete", hashChangeComplete);
         });
 
         it("should both be triggered when pushing a URL", async () => {
@@ -60,6 +66,19 @@ describe("MemoryRouter", () => {
           expect(routeChangeComplete).toHaveBeenCalledWith("/one", {
             shallow: false,
           });
+        });
+
+        it("should trigger only hashEvents on a hash change event", async () => {
+          routeChangeStart.mockClear();
+          routeChangeComplete.mockClear();
+          hashChangeStart.mockClear();
+          hashChangeComplete.mockClear();
+
+          await memoryRouter.push(memoryRouter.asPath + "#foo");
+          expect(hashChangeStart).toHaveBeenCalledWith("/one#foo", { shallow: false });
+          expect(hashChangeStart).toHaveBeenCalledWith("/one#foo", { shallow: false });
+          expect(routeChangeStart).not.toHaveBeenCalled();
+          expect(routeChangeComplete).not.toHaveBeenCalled();
         });
 
         if (async) {

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -45,6 +45,12 @@ describe("MemoryRouter", () => {
         const routeChangeComplete = jest.fn();
         const hashChangeStart = jest.fn();
         const hashChangeComplete = jest.fn();
+        const clearListenerMocks = () => {
+          routeChangeStart.mockClear();
+          routeChangeComplete.mockClear();
+          hashChangeStart.mockClear();
+          hashChangeComplete.mockClear();
+        };
         beforeAll(() => {
           memoryRouter.events.on("routeChangeStart", routeChangeStart);
           memoryRouter.events.on("routeChangeComplete", routeChangeComplete);
@@ -68,17 +74,54 @@ describe("MemoryRouter", () => {
           });
         });
 
-        it("should trigger only hashEvents on a hash change event", async () => {
-          routeChangeStart.mockClear();
-          routeChangeComplete.mockClear();
-          hashChangeStart.mockClear();
-          hashChangeComplete.mockClear();
-
-          await memoryRouter.push(memoryRouter.asPath + "#foo");
-          expect(hashChangeStart).toHaveBeenCalledWith("/one#foo", { shallow: false });
-          expect(hashChangeStart).toHaveBeenCalledWith("/one#foo", { shallow: false });
+        it("should trigger only hashEvents for /baz -> /baz#foo", async () => {
+          await memoryRouter.push("/baz");
+          clearListenerMocks();
+          await memoryRouter.push("/baz#foo");
+          expect(hashChangeStart).toHaveBeenCalledWith("/baz#foo", { shallow: false });
+          expect(hashChangeComplete).toHaveBeenCalledWith("/baz#foo", { shallow: false });
           expect(routeChangeStart).not.toHaveBeenCalled();
           expect(routeChangeComplete).not.toHaveBeenCalled();
+        });
+
+        it("should trigger only hashEvents for /baz#foo -> /baz#foo", async () => {
+          await memoryRouter.push("/baz#foo");
+          clearListenerMocks();
+          await memoryRouter.push("/baz#foo");
+          expect(hashChangeStart).toHaveBeenCalledWith("/baz#foo", { shallow: false });
+          expect(hashChangeComplete).toHaveBeenCalledWith("/baz#foo", { shallow: false });
+          expect(routeChangeStart).not.toHaveBeenCalled();
+          expect(routeChangeComplete).not.toHaveBeenCalled();
+        });
+
+        it("should trigger only hashEvents for /baz#foo -> /baz", async () => {
+          await memoryRouter.push("/baz#foo");
+          clearListenerMocks();
+          await memoryRouter.push("/baz");
+          expect(hashChangeStart).toHaveBeenCalledWith("/baz", { shallow: false });
+          expect(hashChangeComplete).toHaveBeenCalledWith("/baz", { shallow: false });
+          expect(routeChangeStart).not.toHaveBeenCalled();
+          expect(routeChangeComplete).not.toHaveBeenCalled();
+        });
+
+        it("should trigger only routeEvents for /baz -> /baz", async () => {
+          await memoryRouter.push("/baz");
+          clearListenerMocks();
+          await memoryRouter.push("/baz");
+          expect(hashChangeStart).not.toHaveBeenCalled();
+          expect(hashChangeComplete).not.toHaveBeenCalled();
+          expect(routeChangeStart).toHaveBeenCalledWith("/baz", { shallow: false });
+          expect(routeChangeComplete).toHaveBeenCalledWith("/baz", { shallow: false });
+        });
+
+        it("should trigger only routeEvents for /baz -> /foo#baz", async () => {
+          await memoryRouter.push("/baz");
+          clearListenerMocks();
+          await memoryRouter.push("/foo#baz");
+          expect(hashChangeStart).not.toHaveBeenCalled();
+          expect(hashChangeComplete).not.toHaveBeenCalled();
+          expect(routeChangeStart).toHaveBeenCalledWith("/foo#baz", { shallow: false });
+          expect(routeChangeComplete).toHaveBeenCalledWith("/foo#baz", { shallow: false });
         });
 
         if (async) {

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -152,9 +152,20 @@ export class MemoryRouter extends BaseRouter {
     const isHashChange = this.hash !== hash;
     const isQueryChange = stringifyQueryString(this.query) !== stringifyQueryString(query);
     const isRouteChange = isQueryChange || this.pathname !== pathname;
-    const isOnlyHashChange = isHashChange && !isRouteChange;
 
-    if (isOnlyHashChange) {
+    /**
+     * Try to replicate NextJs routing behaviour:
+     *
+     * /foo       -> routeChange
+     * /foo#baz   -> hashChange
+     * /foo#baz   -> hashChange
+     * /foo       -> hashChange
+     * /foo       -> routeChange
+     * /bar#fuz   -> routeChange
+     */
+    const triggersHashChange = !isRouteChange && (isHashChange || Boolean(hash));
+
+    if (triggersHashChange) {
       this.events.emit("hashChangeStart", asPath, { shallow });
     } else {
       this.events.emit("routeChangeStart", asPath, { shallow });
@@ -171,7 +182,7 @@ export class MemoryRouter extends BaseRouter {
       this.locale = options.locale;
     }
 
-    if (isOnlyHashChange) {
+    if (triggersHashChange) {
       this.events.emit("hashChangeComplete", this.asPath, { shallow });
     } else {
       this.events.emit("routeChangeComplete", this.asPath, { shallow });

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -146,18 +146,17 @@ export class MemoryRouter extends BaseRouter {
     const shallow = options?.shallow || false;
     const pathname = removeTrailingSlash(urlObject.pathname || "");
     const query = urlObject.query || {};
-    const hash = urlObject.hash;
+    const hash = urlObject.hash || "";
     const asPath = getRouteAsPath(baseUrlObject.pathname ?? "", baseQuery, hash);
 
     const isHashChange = this.hash !== hash;
     const isQueryChange = stringifyQueryString(this.query) !== stringifyQueryString(query);
     const isRouteChange = isQueryChange || this.pathname !== pathname;
+    const isOnlyHashChange = isHashChange && !isRouteChange;
 
-    if (isHashChange) {
+    if (isOnlyHashChange) {
       this.events.emit("hashChangeStart", asPath, { shallow });
-    }
-
-    if (isRouteChange) {
+    } else {
       this.events.emit("routeChangeStart", asPath, { shallow });
     }
 
@@ -167,15 +166,14 @@ export class MemoryRouter extends BaseRouter {
     this.pathname = pathname;
     this.query = query;
     this.asPath = asPath;
+    this.hash = hash;
     if (options?.locale) {
       this.locale = options.locale;
     }
 
-    if (isHashChange) {
+    if (isOnlyHashChange) {
       this.events.emit("hashChangeComplete", this.asPath, { shallow });
-    }
-
-    if (isRouteChange) {
+    } else {
       this.events.emit("routeChangeComplete", this.asPath, { shallow });
     }
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -15,6 +15,7 @@ describe("next-overridable-hook", () => {
       events: expect.any(Object),
       async: expect.any(Boolean),
       _setCurrentUrl: expect.any(Function),
+      hash: "",
       // Ensure the router has exactly these properties:
       asPath: "",
       basePath: "",

--- a/src/useMemoryRouter.test.tsx
+++ b/src/useMemoryRouter.test.tsx
@@ -49,15 +49,15 @@ export function useRouterTests(singletonRouter: MemoryRouter, useRouter: () => R
     const { result } = renderHook(() => useRouter());
 
     await act(async () => {
-      await result.current.push("/foo?bar=baz");
+      await result.current.push("/foo?bar=baz2");
     });
 
     expect(result.current).not.toBe(singletonRouter);
     expect(result.current).toEqual(singletonRouter);
     expect(result.current).toMatchObject({
-      asPath: "/foo?bar=baz",
+      asPath: "/foo?bar=baz2",
       pathname: "/foo",
-      query: { bar: "baz" },
+      query: { bar: "baz2" },
     });
 
     // Ensure only 2 renders happened:

--- a/src/useMemoryRouter.test.tsx
+++ b/src/useMemoryRouter.test.tsx
@@ -49,15 +49,15 @@ export function useRouterTests(singletonRouter: MemoryRouter, useRouter: () => R
     const { result } = renderHook(() => useRouter());
 
     await act(async () => {
-      await result.current.push("/foo?bar=baz2");
+      await result.current.push("/foo?bar=baz");
     });
 
     expect(result.current).not.toBe(singletonRouter);
     expect(result.current).toEqual(singletonRouter);
     expect(result.current).toMatchObject({
-      asPath: "/foo?bar=baz2",
+      asPath: "/foo?bar=baz",
       pathname: "/foo",
-      query: { bar: "baz2" },
+      query: { bar: "baz" },
     });
 
     // Ensure only 2 renders happened:

--- a/src/useMemoryRouter.tsx
+++ b/src/useMemoryRouter.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { MemoryRouter } from "./MemoryRouter";
 
 export type MemoryRouterEventHandlers = {
+  onHashChangeStart?: (url: string, options: { shallow: boolean }) => void;
+  onHashChangeComplete?: (url: string, options: { shallow: boolean }) => void;
   onRouteChangeStart?: (url: string, options: { shallow: boolean }) => void;
   onRouteChangeComplete?: (url: string, options: { shallow: boolean }) => void;
   onPush?: (url: string, options: { shallow: boolean }) => void;
@@ -34,16 +36,20 @@ export const useMemoryRouter = (singletonRouter: MemoryRouter, eventHandlers?: M
   // Subscribe to any eventHandlers:
   useEffect(() => {
     if (!eventHandlers) return;
-    const { onRouteChangeStart, onRouteChangeComplete, onPush, onReplace } = eventHandlers;
-    if (!(onRouteChangeStart || onRouteChangeComplete || onPush || onReplace)) return;
+    const { onRouteChangeStart, onRouteChangeComplete, onHashChangeComplete, onHashChangeStart, onPush, onReplace } = eventHandlers;
+    if (!(onRouteChangeStart || onRouteChangeComplete  || onHashChangeStart ||onHashChangeComplete || onPush || onReplace)) return;
 
     if (onRouteChangeStart) singletonRouter.events.on("routeChangeStart", onRouteChangeStart);
     if (onRouteChangeComplete) singletonRouter.events.on("routeChangeComplete", onRouteChangeComplete);
+    if (onHashChangeStart) singletonRouter.events.on("hashChangeStart", onHashChangeStart);
+    if (onRouteChangeComplete) singletonRouter.events.on("hashChangeComplete", onRouteChangeComplete);
     if (onPush) singletonRouter.events.on("NEXT_ROUTER_MOCK:push", onPush);
     if (onReplace) singletonRouter.events.on("NEXT_ROUTER_MOCK:replace", onReplace);
     return () => {
       if (onRouteChangeStart) singletonRouter.events.off("routeChangeStart", onRouteChangeStart);
       if (onRouteChangeComplete) singletonRouter.events.off("routeChangeComplete", onRouteChangeComplete);
+      if (onHashChangeStart) singletonRouter.events.off("hashChangeStart", onHashChangeStart);
+      if (onHashChangeComplete) singletonRouter.events.off("hashChangeComplete", onHashChangeComplete);
       if (onPush) singletonRouter.events.off("NEXT_ROUTER_MOCK:push", onPush);
       if (onReplace) singletonRouter.events.off("NEXT_ROUTER_MOCK:replace", onReplace);
     };
@@ -51,6 +57,8 @@ export const useMemoryRouter = (singletonRouter: MemoryRouter, eventHandlers?: M
     singletonRouter.events,
     eventHandlers?.onRouteChangeStart,
     eventHandlers?.onRouteChangeComplete,
+    eventHandlers?.onHashChangeStart,
+    eventHandlers?.onHashChangeComplete,
     eventHandlers?.onPush,
     eventHandlers?.onReplace,
   ]);

--- a/src/useMemoryRouter.tsx
+++ b/src/useMemoryRouter.tsx
@@ -36,13 +36,18 @@ export const useMemoryRouter = (singletonRouter: MemoryRouter, eventHandlers?: M
   // Subscribe to any eventHandlers:
   useEffect(() => {
     if (!eventHandlers) return;
-    const { onRouteChangeStart, onRouteChangeComplete, onHashChangeComplete, onHashChangeStart, onPush, onReplace } = eventHandlers;
-    if (!(onRouteChangeStart || onRouteChangeComplete  || onHashChangeStart ||onHashChangeComplete || onPush || onReplace)) return;
-
+    const {
+      onRouteChangeStart,
+      onRouteChangeComplete,
+      onHashChangeComplete,
+      onHashChangeStart,
+      onPush,
+      onReplace,
+    } = eventHandlers;
     if (onRouteChangeStart) singletonRouter.events.on("routeChangeStart", onRouteChangeStart);
     if (onRouteChangeComplete) singletonRouter.events.on("routeChangeComplete", onRouteChangeComplete);
     if (onHashChangeStart) singletonRouter.events.on("hashChangeStart", onHashChangeStart);
-    if (onRouteChangeComplete) singletonRouter.events.on("hashChangeComplete", onRouteChangeComplete);
+    if (onHashChangeComplete) singletonRouter.events.on("hashChangeComplete", onHashChangeComplete);
     if (onPush) singletonRouter.events.on("NEXT_ROUTER_MOCK:push", onPush);
     if (onReplace) singletonRouter.events.on("NEXT_ROUTER_MOCK:replace", onReplace);
     return () => {


### PR DESCRIPTION
this PR adds support for two router events (see [https://nextjs.org/docs/api-reference/next/router#routerevents](https://nextjs.org/docs/api-reference/next/router#routerevents)):

- hashChangeStart
- hashChangeComplete

it uses the current url of the MemoryRouter to detect if the `hash` or the `route` was changed and triggers only the matching events (that's the behaviour of next 11)

unfortunately the unit will now test fail if the previous test navigated to the same route.  
I adjusted the test (second commit) to go to a dedicated route instead but I am not sure if this is the desired solution
