### PR TITLE
Explicitly define `children` for React 18 compat

### DIFF
--- a/src/MemoryRouterProvider/MemoryRouterProvider-10.tsx
+++ b/src/MemoryRouterProvider/MemoryRouterProvider-10.tsx
@@ -1,7 +1,7 @@
 // NOTE: this path works with Next v10-v11.0.1
 // @ts-ignore
 import { RouterContext } from "next/dist/next-server/lib/router-context";
-import React, { FC, useMemo } from "react";
+import React, { FC, ReactNode, useMemo } from "react";
 
 import { useMemoryRouter, MemoryRouter, Url } from "../index";
 import { MemoryRouterEventHandlers } from "../useMemoryRouter";
@@ -10,6 +10,7 @@ export type MemoryRouterProviderProps = {
   /** The initial URL to render */
   url?: Url;
   async?: boolean;
+  children?: ReactNode;
 } & MemoryRouterEventHandlers;
 
 export const MemoryRouterProvider: FC<MemoryRouterProviderProps> = ({ children, url, async, ...eventHandlers }) => {

--- a/src/MemoryRouterProvider/MemoryRouterProvider-11.1.tsx
+++ b/src/MemoryRouterProvider/MemoryRouterProvider-11.1.tsx
@@ -1,7 +1,7 @@
 // NOTE: this path works with Next v11.1.0+
 //
 import { RouterContext } from "next/dist/shared/lib/router-context";
-import React, { FC, useMemo } from "react";
+import React, { FC, ReactNode, useMemo } from "react";
 
 import { useMemoryRouter, MemoryRouter, Url } from "../index";
 import { MemoryRouterEventHandlers } from "../useMemoryRouter";
@@ -10,6 +10,7 @@ export type MemoryRouterProviderProps = {
   /** The initial URL to render */
   url?: Url;
   async?: boolean;
+  children?: ReactNode;
 } & MemoryRouterEventHandlers;
 
 export const MemoryRouterProvider: FC<MemoryRouterProviderProps> = ({ children, url, async, ...eventHandlers }) => {


### PR DESCRIPTION
Fixes #40 
