### PR TITLE
added support for as param in setCurrentUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ it('next/link can be tested too', async () => {
 
 - `useRouter()`
 - `withRouter(Component)`
-- `router.push(url, as, options)`
-- `router.replace(url, as, options)`
+- `router.push(url, as?, options?)`
+- `router.replace(url, as?, options?)`
 - `router.pathname`
 - `router.asPath`
 - `router.query`

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -326,88 +326,87 @@ describe("MemoryRouter", () => {
           });
         });
 
-        describe(`if as path matches href path, href query is used`, () => {
-          it.each([
-            ["/path?queryParam=123", "/path", { asPath: "/path", pathname: "/path", query: { queryParam: "123" } }],
-            [
-              "/path?queryParam=123",
-              { pathname: "/path" },
-              { asPath: "/path", pathname: "/path", query: { queryParam: "123" } },
-            ],
-            [
-              "/path?queryParam=123",
-              "/path?differentQueryParam=456",
-              { asPath: "/path?differentQueryParam=456", pathname: "/path", query: { queryParam: "123" } },
-            ],
-            [
-              "/path?queryParam=123",
-              { pathname: "/path", query: { differentQueryParam: "456" } },
-              { asPath: "/path?differentQueryParam=456", pathname: "/path", query: { queryParam: "123" } },
-            ],
-          ])("url: %s, as: %s, expected: %s", async (url, as, expected) => {
-            await memoryRouter.push(url, as);
-            expect(memoryRouter).toMatchObject(expected);
+        it(`if as path matches href path, href query is used`, async () => {
+          await memoryRouter.push("/path?queryParam=123", "/path");
+          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", query: { queryParam: "123" } });
+
+          await memoryRouter.push("/path?queryParam=123", { pathname: "/path" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", query: { queryParam: "123" } });
+
+          await memoryRouter.push("/path?queryParam=123", "/path?differentQueryParam=456");
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path?differentQueryParam=456",
+            pathname: "/path",
+            query: { queryParam: "123" },
+          });
+
+          await memoryRouter.push("/path?queryParam=123", {
+            pathname: "/path",
+            query: { differentQueryParam: "456" },
+          });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path?differentQueryParam=456",
+            pathname: "/path",
+            query: { queryParam: "123" },
           });
         });
 
-        describe("if as path does not match href path, as query is used", () => {
-          it.each([
-            [
-              "/path?queryParam=123",
-              "/differentPath?differentQueryParam=456",
-              {
-                asPath: "/differentPath?differentQueryParam=456",
-                pathname: "/differentPath",
-                query: { differentQueryParam: "456" },
-              },
-            ],
-            [
-              "/path?queryParam=123",
-              { pathname: "/differentPath", query: { differentQueryParam: "456" } },
-              {
-                asPath: "/differentPath?differentQueryParam=456",
-                pathname: "/differentPath",
-                query: { differentQueryParam: "456" },
-              },
-            ],
-          ])("url: %s, as: %s, expected: %s", async (url, as, expected) => {
-            await memoryRouter.push(url, as);
-            expect(memoryRouter).toMatchObject(expected);
+        it("if as path does not match href path, as query is used", async () => {
+          await memoryRouter.push("/path?queryParam=123", "/differentPath?differentQueryParam=456");
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath?differentQueryParam=456",
+            pathname: "/differentPath",
+            query: { differentQueryParam: "456" },
+          });
+
+          await memoryRouter.push("/path?queryParam=123", {
+            pathname: "/differentPath",
+            query: { differentQueryParam: "456" },
+          });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath?differentQueryParam=456",
+            pathname: "/differentPath",
+            query: { differentQueryParam: "456" },
           });
         });
 
-        describe("as param hash overrides href hash", () => {
-          it.each([
-            ["/path", "/path#hash", { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
-            ["/path", { pathname: "/path", hash: "#hash" }, { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
-            ["/path#originalHash", "/path#hash", { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
-            ["/path", { pathname: "/path", hash: "#hash" }, { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
-            ["/path#originalHash", "/path", { asPath: "/path", pathname: "/path", hash: "" }],
-            ["/path", { pathname: "/path" }, { asPath: "/path", pathname: "/path", hash: "" }],
-            [
-              "/path#originalHash",
-              "/differentPath",
-              { asPath: "/differentPath", pathname: "/differentPath", hash: "" },
-            ],
-            [
-              "/path",
-              { pathname: "/differentPath" },
-              { asPath: "/differentPath", pathname: "/differentPath", hash: "" },
-            ],
-            [
-              "/path#originalHash",
-              "/differentPath#hash",
-              { asPath: "/differentPath#hash", pathname: "/differentPath", hash: "#hash" },
-            ],
-            [
-              "/path",
-              { pathname: "/differentPath", hash: "#hash" },
-              { asPath: "/differentPath#hash", pathname: "/differentPath", hash: "#hash" },
-            ],
-          ])("url: %s, as: %s, expected: %s", async (url, as, expectedResult) => {
-            await memoryRouter.push(url, as);
+        it("as param hash overrides href hash", async () => {
+          await memoryRouter.push("/path", "/path#hash");
+          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
 
-            expect(memoryRouter).toMatchObject(expectedResult);
+          await memoryRouter.push("/path", { pathname: "/path", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+
+          await memoryRouter.push("/path#originalHash", "/path#hash");
+          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+
+          await memoryRouter.push("/path", { pathname: "/path", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+
+          await memoryRouter.push("/path#originalHash", "/path");
+          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", hash: "" });
+
+          await memoryRouter.push("/path", { pathname: "/path" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", hash: "" });
+
+          await memoryRouter.push("/path#originalHash", "/differentPath");
+          expect(memoryRouter).toMatchObject({ asPath: "/differentPath", pathname: "/differentPath", hash: "" });
+
+          await memoryRouter.push("/path", { pathname: "/differentPath" });
+          expect(memoryRouter).toMatchObject({ asPath: "/differentPath", pathname: "/differentPath", hash: "" });
+
+          await memoryRouter.push("/path#originalHash", "/differentPath#hash");
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath#hash",
+            pathname: "/differentPath",
+            hash: "#hash",
+          });
+
+          await memoryRouter.push("/path", { pathname: "/differentPath", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath#hash",
+            pathname: "/differentPath",
+            hash: "#hash",
           });
         });
       });

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -315,6 +315,24 @@ describe("MemoryRouter", () => {
         });
       });
 
+      it("correctly uses default as param", async () => {
+        memoryRouter.setCurrentUrl("/path?queryParam=123");
+        expect(memoryRouter).toMatchObject({
+          asPath: "/path?queryParam=123",
+          pathname: "/path",
+          query: { queryParam: "123" },
+        });
+      });
+
+      it("supports as param", async () => {
+        memoryRouter.setCurrentUrl("/path?queryParam=123", "/path");
+        expect(memoryRouter).toMatchObject({
+          asPath: "/path",
+          pathname: "/path",
+          query: { queryParam: "123" },
+        });
+      });
+
       it("should allow deconstruction of push and replace", async () => {
         const { push, replace } = memoryRouter;
         await push("/one");

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -1,4 +1,5 @@
 import { MemoryRouter } from "./MemoryRouter";
+import { createDynamicRouteParser } from "./dynamic-routes/next-12";
 
 describe("MemoryRouter", () => {
   beforeEach(() => {
@@ -324,13 +325,79 @@ describe("MemoryRouter", () => {
         });
       });
 
-      it("supports as param", async () => {
-        memoryRouter.setCurrentUrl("/path?queryParam=123", "/path");
+      it("uses as path param over href path param", async () => {
+        const unregisterParser = memoryRouter.useParser(createDynamicRouteParser(["/path/[testParam]"]));
+
+        memoryRouter.setCurrentUrl("/path/123", "/path/456");
         expect(memoryRouter).toMatchObject({
-          asPath: "/path",
-          pathname: "/path",
-          query: { queryParam: "123" },
+          asPath: "/path/456",
+          pathname: "/path/[testParam]",
+          query: {
+            testParam: "456",
+          },
         });
+
+        // Cleanup
+        unregisterParser();
+      });
+
+      it.each([
+        ["/path?queryParam=123", "/path", { asPath: "/path", pathname: "/path", query: { queryParam: "123" } }],
+        [
+          "/path?queryParam=123",
+          { pathname: "/path" },
+          { asPath: "/path", pathname: "/path", query: { queryParam: "123" } },
+        ],
+        [
+          "/path?queryParam=123",
+          "/path?differentQueryParam=456",
+          { asPath: "/path?differentQueryParam=456", pathname: "/path", query: { queryParam: "123" } },
+        ],
+        [
+          "/path?queryParam=123",
+          { pathname: "/path", query: { differentQueryParam: "456" } },
+          { asPath: "/path?differentQueryParam=456", pathname: "/path", query: { queryParam: "123" } },
+        ],
+      ])("uses href query if as path equals href path", async (url, as, expectedResult) => {
+        memoryRouter.setCurrentUrl(url, as);
+        expect(memoryRouter).toMatchObject(expectedResult);
+      });
+
+      it.each([
+        "/differentPath?differentQueryParam=456",
+        { pathname: "/differentPath", query: { differentQueryParam: "456" } },
+      ])("uses as path query if as path does not equal href path", async (as) => {
+        memoryRouter.setCurrentUrl("/path?queryParam=123", as);
+        expect(memoryRouter).toMatchObject({
+          asPath: "/differentPath?differentQueryParam=456",
+          pathname: "/differentPath",
+          query: { differentQueryParam: "456" },
+        });
+      });
+
+      it.each([
+        ["/path", "/path#hash", { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
+        ["/path", { pathname: "/path", hash: "#hash" }, { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
+        ["/path#originalHash", "/path#hash", { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
+        ["/path", { pathname: "/path", hash: "#hash" }, { asPath: "/path#hash", pathname: "/path", hash: "#hash" }],
+        ["/path#originalHash", "/path", { asPath: "/path", pathname: "/path", hash: "" }],
+        ["/path", { pathname: "/path" }, { asPath: "/path", pathname: "/path", hash: "" }],
+        ["/path#originalHash", "/differentPath", { asPath: "/differentPath", pathname: "/differentPath", hash: "" }],
+        ["/path", { pathname: "/differentPath" }, { asPath: "/differentPath", pathname: "/differentPath", hash: "" }],
+        [
+          "/path#originalHash",
+          "/differentPath#hash",
+          { asPath: "/differentPath#hash", pathname: "/differentPath", hash: "#hash" },
+        ],
+        [
+          "/path",
+          { pathname: "/differentPath", hash: "#hash" },
+          { asPath: "/differentPath#hash", pathname: "/differentPath", hash: "#hash" },
+        ],
+      ])("hash from as param overwrites hash from path", async (url, as, expectedResult) => {
+        memoryRouter.setCurrentUrl(url, as);
+
+        expect(memoryRouter).toMatchObject(expectedResult);
       });
 
       it("should allow deconstruction of push and replace", async () => {
@@ -354,6 +421,7 @@ describe("MemoryRouter", () => {
         expect(memoryRouter).toMatchObject({
           asPath: "/path#hash",
           pathname: "/path",
+          hash: "#hash",
         });
 
         memoryRouter.setCurrentUrl("/path?key=value#hash");
@@ -361,6 +429,7 @@ describe("MemoryRouter", () => {
           asPath: "/path?key=value#hash",
           pathname: "/path",
           query: { key: "value" },
+          hash: "#hash",
         });
       });
 

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -139,10 +139,10 @@ export class MemoryRouter extends BaseRouter {
       asPath = getRouteAsPath(asRoute.pathname, asRoute.query, asRoute.hash);
     }
 
-    // Check equality of raw pathnames before they are parsed (e.g. /path/1 !== /path/2 but /path/[id] === /path/[id])
+    // Compare pathnames before they are parsed (e.g. /path/1 !== /path/2 but /path/[id] === /path/[id])
     const rawPathnamesDiffer = asRoute?.pathname !== newRoute.pathname;
 
-    // Optionally apply dynamic routes
+    // Optionally apply dynamic routes (can mutate routes)
     this.events.emit("NEXT_ROUTER_MOCK:parse", newRoute);
     if (asRoute) {
       this.events.emit("NEXT_ROUTER_MOCK:parse", asRoute);
@@ -163,13 +163,15 @@ export class MemoryRouter extends BaseRouter {
 
     // Update this instance:
     this.asPath = asPath;
-    // If asURL has a different path name than hrefURL, asURL takes precedence
-    this.pathname = asRoute ? asRoute.pathname : newRoute.pathname;
-    // If asURL and hrefURL have different paths, we use query of asURL, otherwise from hrefURL
-    this.query = asRoute && rawPathnamesDiffer ? asRoute.query : newRoute.query;
-    // asURL hash always takes precedence over hrefURL
-    this.hash = asRoute ? asRoute.hash : newRoute.hash;
-
+    if (asRoute) {
+      this.pathname = asRoute.pathname;
+      this.query = rawPathnamesDiffer ? asRoute.query : newRoute.query;
+      this.hash = asRoute.hash;
+    } else {
+      this.pathname = newRoute.pathname;
+      this.query = newRoute.query;
+      this.hash = newRoute.hash;
+    }
     if (options?.locale) {
       this.locale = options.locale;
     }

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -145,9 +145,9 @@ export class MemoryRouter extends BaseRouter {
   /**
    * Sets the current Memory route to the specified url, synchronously.
    */
-  public setCurrentUrl = (url: Url) => {
+  public setCurrentUrl = (url: Url, as?: Url) => {
     // (ignore the returned promise)
-    void this._setCurrentUrl(url, undefined, undefined, "set", false);
+    void this._setCurrentUrl(url, as, undefined, "set", false);
   };
 
   private async _setCurrentUrl(
@@ -165,7 +165,19 @@ export class MemoryRouter extends BaseRouter {
       query: parsedUrl.query || {},
       hash: parsedUrl.hash || "",
     };
-    const asPath = getRouteAsPath(newRoute.pathname, newRoute.query, newRoute.hash);
+
+    let asPath: string;
+    if (as === undefined) {
+      asPath = getRouteAsPath(newRoute.pathname, newRoute.query, newRoute.hash);
+    } else {
+      const parsedAsUrl = typeof as === "object" ? as : parseUrl(as, true);
+      let asRoute: UrlObjectComplete = {
+        pathname: removeTrailingSlash(parsedAsUrl.pathname ?? this.pathname),
+        query: parsedAsUrl.query || {},
+        hash: parsedAsUrl.hash || "",
+      };
+      asPath = getRouteAsPath(asRoute.pathname, asRoute.query, asRoute.hash);
+    }
 
     // Optionally apply dynamic routes:
     this.events.emit("NEXT_ROUTER_MOCK:parse", newRoute);

--- a/src/dynamic-routes/createDynamicRouteParser.test.tsx
+++ b/src/dynamic-routes/createDynamicRouteParser.test.tsx
@@ -140,6 +140,21 @@ describe("dynamic routes", () => {
     });
   });
 
+  describe('the "as" parameter', () => {
+    it("uses as path param over href path param", async () => {
+      memoryRouter.useParser(createDynamicRouteParser(["/path/[testParam]"]));
+
+      memoryRouter.push("/path/123", "/path/456");
+      expect(memoryRouter).toMatchObject({
+        asPath: "/path/456",
+        pathname: "/path/[testParam]",
+        query: {
+          testParam: "456",
+        },
+      });
+    });
+  });
+
   it("hashes are preserved", async () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]"]));
 


### PR DESCRIPTION
Fixes #63 

Added `as` as new optional param within `setCurrentUrl` to enable setting up an asPath.
Depending on if `as` is defined, `_setCurrentUrl` differentiates how `asPath` is defined:
* if `as` is defined, the already existing url parsing logic is reused in order to compute a correct `asPath`.
* if `as` is undefined, the previous default logic is applied.