### PR TITLE
Add route support

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ it('next/link can be tested too', async () => {
 - `withRouter(Component)`
 - `router.push(url, as?, options?)`
 - `router.replace(url, as?, options?)`
+- `router.route`
 - `router.pathname`
 - `router.asPath`
 - `router.query`
@@ -287,7 +288,6 @@ PRs welcome!
 These fields just have default values; these methods do nothing.
 
 - `router.isReady`
-- `router.route`
 - `router.basePath`
 - `router.isFallback`
 - `router.isLocaleDomain`

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -14,6 +14,7 @@ describe("MemoryRouter", () => {
       it("should start empty", async () => {
         expect(memoryRouter).toMatchObject({
           asPath: "",
+          route: "",
           pathname: "",
           query: {},
           locale: undefined,
@@ -24,6 +25,7 @@ describe("MemoryRouter", () => {
 
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three",
+          route: "/one/two/three",
           pathname: "/one/two/three",
           query: {},
         });
@@ -32,6 +34,7 @@ describe("MemoryRouter", () => {
 
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three?four=4&five=",
+          route: "/one/two/three",
           pathname: "/one/two/three",
           query: {
             five: "",
@@ -186,6 +189,7 @@ describe("MemoryRouter", () => {
         await memoryRouter.push({ pathname: "/one" });
         expect(memoryRouter).toMatchObject({
           asPath: "/one",
+          route: "/one",
           pathname: "/one",
           query: {},
         });
@@ -196,6 +200,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three?four=4&five=",
+          route: "/one/two/three",
           pathname: "/one/two/three",
           query: {
             five: "",
@@ -210,6 +215,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two",
+          route: "/one/[id]",
           pathname: "/one/[id]",
           query: {
             id: "two",
@@ -222,6 +228,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three",
+          route: "/one/[id]/three",
           pathname: "/one/[id]/three",
           query: {
             id: "two",
@@ -234,6 +241,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three?four=4",
+          route: "/one/[id]/three",
           pathname: "/one/[id]/three",
           query: {
             four: "4",
@@ -246,6 +254,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three/4",
+          route: "/one/[id]/three/[four]",
           pathname: "/one/[id]/three/[four]",
           query: {
             four: "4",
@@ -258,6 +267,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three/four?filter=abc",
+          route: "/one/[...slug]",
           pathname: "/one/[...slug]",
           query: {
             slug: ["two", "three", "four"],
@@ -270,6 +280,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two/three/four",
+          route: "/one/two/[[...slug]]",
           pathname: "/one/two/[[...slug]]",
           query: {},
         });
@@ -279,6 +290,7 @@ describe("MemoryRouter", () => {
         });
         expect(memoryRouter).toMatchObject({
           asPath: "/one/two",
+          route: "/one/two/[[...slug]]",
           pathname: "/one/two/[[...slug]]",
           query: {},
         });
@@ -304,6 +316,7 @@ describe("MemoryRouter", () => {
         memoryRouter.setCurrentUrl("/path/");
         expect(memoryRouter).toMatchObject({
           asPath: "/path",
+          route: "/path",
           pathname: "/path",
         });
       });
@@ -312,6 +325,7 @@ describe("MemoryRouter", () => {
         memoryRouter.setCurrentUrl("/");
         expect(memoryRouter).toMatchObject({
           asPath: "/",
+          route: "/",
           pathname: "/",
         });
       });
@@ -321,6 +335,7 @@ describe("MemoryRouter", () => {
           await memoryRouter.push("/path?queryParam=123");
           expect(memoryRouter).toMatchObject({
             asPath: "/path?queryParam=123",
+            route: "/path",
             pathname: "/path",
             query: { queryParam: "123" },
           });
@@ -328,14 +343,25 @@ describe("MemoryRouter", () => {
 
         it(`if as path matches href path, href query is used`, async () => {
           await memoryRouter.push("/path?queryParam=123", "/path");
-          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", query: { queryParam: "123" } });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path",
+            route: "/path",
+            pathname: "/path",
+            query: { queryParam: "123" },
+          });
 
           await memoryRouter.push("/path?queryParam=123", { pathname: "/path" });
-          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", query: { queryParam: "123" } });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path",
+            route: "/path",
+            pathname: "/path",
+            query: { queryParam: "123" },
+          });
 
           await memoryRouter.push("/path?queryParam=123", "/path?differentQueryParam=456");
           expect(memoryRouter).toMatchObject({
             asPath: "/path?differentQueryParam=456",
+            route: "/path",
             pathname: "/path",
             query: { queryParam: "123" },
           });
@@ -346,6 +372,7 @@ describe("MemoryRouter", () => {
           });
           expect(memoryRouter).toMatchObject({
             asPath: "/path?differentQueryParam=456",
+            route: "/path",
             pathname: "/path",
             query: { queryParam: "123" },
           });
@@ -355,6 +382,7 @@ describe("MemoryRouter", () => {
           await memoryRouter.push("/path?queryParam=123", "/differentPath?differentQueryParam=456");
           expect(memoryRouter).toMatchObject({
             asPath: "/differentPath?differentQueryParam=456",
+            route: "/differentPath",
             pathname: "/differentPath",
             query: { differentQueryParam: "456" },
           });
@@ -365,6 +393,7 @@ describe("MemoryRouter", () => {
           });
           expect(memoryRouter).toMatchObject({
             asPath: "/differentPath?differentQueryParam=456",
+            route: "/differentPath",
             pathname: "/differentPath",
             query: { differentQueryParam: "456" },
           });
@@ -372,32 +401,58 @@ describe("MemoryRouter", () => {
 
         it("as param hash overrides href hash", async () => {
           await memoryRouter.push("/path", "/path#hash");
-          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path#hash",
+            route: "/path",
+            pathname: "/path",
+            hash: "#hash",
+          });
 
           await memoryRouter.push("/path", { pathname: "/path", hash: "#hash" });
-          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path#hash",
+            route: "/path",
+            pathname: "/path",
+            hash: "#hash",
+          });
 
           await memoryRouter.push("/path#originalHash", "/path#hash");
-          expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/path#hash",
+            route: "/path",
+            pathname: "/path",
+            hash: "#hash",
+          });
 
           await memoryRouter.push("/path", { pathname: "/path", hash: "#hash" });
           expect(memoryRouter).toMatchObject({ asPath: "/path#hash", pathname: "/path", hash: "#hash" });
 
           await memoryRouter.push("/path#originalHash", "/path");
-          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", hash: "" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path", route: "/path", pathname: "/path", hash: "" });
 
           await memoryRouter.push("/path", { pathname: "/path" });
-          expect(memoryRouter).toMatchObject({ asPath: "/path", pathname: "/path", hash: "" });
+          expect(memoryRouter).toMatchObject({ asPath: "/path", route: "/path", pathname: "/path", hash: "" });
 
           await memoryRouter.push("/path#originalHash", "/differentPath");
-          expect(memoryRouter).toMatchObject({ asPath: "/differentPath", pathname: "/differentPath", hash: "" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath",
+            route: "/differentPath",
+            pathname: "/differentPath",
+            hash: "",
+          });
 
           await memoryRouter.push("/path", { pathname: "/differentPath" });
-          expect(memoryRouter).toMatchObject({ asPath: "/differentPath", pathname: "/differentPath", hash: "" });
+          expect(memoryRouter).toMatchObject({
+            asPath: "/differentPath",
+            route: "/differentPath",
+            pathname: "/differentPath",
+            hash: "",
+          });
 
           await memoryRouter.push("/path#originalHash", "/differentPath#hash");
           expect(memoryRouter).toMatchObject({
             asPath: "/differentPath#hash",
+            route: "/differentPath",
             pathname: "/differentPath",
             hash: "#hash",
           });
@@ -405,6 +460,7 @@ describe("MemoryRouter", () => {
           await memoryRouter.push("/path", { pathname: "/differentPath", hash: "#hash" });
           expect(memoryRouter).toMatchObject({
             asPath: "/differentPath#hash",
+            route: "/differentPath",
             pathname: "/differentPath",
             hash: "#hash",
           });
@@ -431,6 +487,7 @@ describe("MemoryRouter", () => {
         memoryRouter.setCurrentUrl("/path#hash");
         expect(memoryRouter).toMatchObject({
           asPath: "/path#hash",
+          route: "/path",
           pathname: "/path",
           hash: "#hash",
         });
@@ -438,6 +495,7 @@ describe("MemoryRouter", () => {
         memoryRouter.setCurrentUrl("/path?key=value#hash");
         expect(memoryRouter).toMatchObject({
           asPath: "/path?key=value#hash",
+          route: "/path",
           pathname: "/path",
           query: { key: "value" },
           hash: "#hash",

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -36,7 +36,6 @@ type InternalEventTypes =
  */
 export abstract class BaseRouter implements NextRouter {
   isReady = true;
-  route = "";
   pathname = "";
   hash = "";
   query: NextRouter["query"] = {};
@@ -69,6 +68,11 @@ export abstract class BaseRouter implements NextRouter {
   }
   reload() {
     // Do nothing
+  }
+
+  // Keep route and pathname values in sync
+  get route() {
+    return this.pathname;
   }
 }
 

--- a/src/dynamic-routes/createDynamicRouteParser.test.tsx
+++ b/src/dynamic-routes/createDynamicRouteParser.test.tsx
@@ -12,6 +12,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/entity/101/attribute/everything");
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]/attribute/[name]",
       pathname: "/entity/[id]/attribute/[name]",
       asPath: "/entity/101/attribute/everything",
       query: {
@@ -26,6 +27,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/one/two/three");
     expect(memoryRouter).toMatchObject({
+      route: "/[...slug]",
       pathname: "/[...slug]",
       asPath: "/one/two/three",
       query: {
@@ -39,6 +41,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/one/two/three");
     expect(memoryRouter).toMatchObject({
+      route: "/one/two/three",
       pathname: "/one/two/three",
       asPath: "/one/two/three",
       query: {},
@@ -50,6 +53,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/entity/list");
     expect(memoryRouter).toMatchObject({
+      route: "/entity/list",
       pathname: "/entity/list",
       asPath: "/entity/list",
       query: {},
@@ -62,6 +66,7 @@ describe("dynamic routes", () => {
     memoryRouter.push("/entity/100?id=500");
 
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       query: { id: "100" },
       asPath: "/entity/100?id=500",
@@ -74,6 +79,7 @@ describe("dynamic routes", () => {
     memoryRouter.push({ pathname: "/entity/[id]", query: { id: "42" } });
 
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       asPath: "/entity/42",
       query: { id: "42" },
@@ -86,6 +92,7 @@ describe("dynamic routes", () => {
     memoryRouter.push({ pathname: "/entity/[id]", query: { id: "42", filter: "abc" } });
 
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       asPath: "/entity/42?filter=abc",
       query: { id: "42", filter: "abc" },
@@ -98,6 +105,7 @@ describe("dynamic routes", () => {
     memoryRouter.push({ pathname: "/[...slug]", query: { slug: ["one", "two", "three"] } });
 
     expect(memoryRouter).toMatchObject({
+      route: "/[...slug]",
       pathname: "/[...slug]",
       asPath: "/one/two/three",
       query: { slug: ["one", "two", "three"] },
@@ -110,6 +118,7 @@ describe("dynamic routes", () => {
     memoryRouter.push({ pathname: "/entity/100", query: { filter: "abc", max: "1000" } });
 
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       asPath: "/entity/100?filter=abc&max=1000",
       query: { id: "100", filter: "abc", max: "1000" },
@@ -122,6 +131,7 @@ describe("dynamic routes", () => {
     memoryRouter.push("/one/two/three/four");
 
     expect(memoryRouter).toMatchObject({
+      route: "/one/two/[[...slug]]",
       pathname: "/one/two/[[...slug]]",
       asPath: "/one/two/three/four",
       query: { slug: ["three", "four"] },
@@ -134,6 +144,7 @@ describe("dynamic routes", () => {
     memoryRouter.push("/entity/42");
 
     expect(memoryRouter).toMatchObject({
+      route: "/entity/[id]/[[...slug]]",
       pathname: "/entity/[id]/[[...slug]]",
       asPath: "/entity/42",
       query: { id: "42" },
@@ -147,6 +158,7 @@ describe("dynamic routes", () => {
       memoryRouter.push("/path/123", "/path/456");
       expect(memoryRouter).toMatchObject({
         asPath: "/path/456",
+        route: "/path/[testParam]",
         pathname: "/path/[testParam]",
         query: {
           testParam: "456",
@@ -161,6 +173,7 @@ describe("dynamic routes", () => {
     memoryRouter.setCurrentUrl("/entity/42#hash");
     expect(memoryRouter).toMatchObject({
       asPath: "/entity/42#hash",
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       hash: "#hash",
     });
@@ -168,6 +181,7 @@ describe("dynamic routes", () => {
     memoryRouter.setCurrentUrl("/entity/42?key=value#hash");
     expect(memoryRouter).toMatchObject({
       asPath: "/entity/42?key=value#hash",
+      route: "/entity/[id]",
       pathname: "/entity/[id]",
       query: { key: "value", id: "42" },
     });

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -30,7 +30,6 @@ describe("next-overridable-hook", () => {
       locales: [],
       pathname: "",
       query: {},
-      route: "",
     });
   });
 

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -17,6 +17,7 @@ describe("next/link", () => {
       await waitFor(() => {
         expect(memoryRouter).toMatchObject({
           asPath: "/example?foo=bar",
+          route: "/example",
           pathname: "/example",
           query: { foo: "bar" },
         });
@@ -29,6 +30,7 @@ describe("next/link", () => {
       await waitFor(() => {
         expect(memoryRouter).toMatchObject({
           asPath: "/example?foo=bar",
+          route: "/example",
           pathname: "/example",
           query: { foo: "bar" },
         });

--- a/src/useMemoryRouter.test.tsx
+++ b/src/useMemoryRouter.test.tsx
@@ -55,6 +55,7 @@ export function useRouterTests(singletonRouter: MemoryRouter, useRouter: () => M
     expect(result.current).toEqual(singletonRouter);
     expect(result.current).toMatchObject({
       asPath: "/foo?bar=baz",
+      route: "/foo",
       pathname: "/foo",
       query: { bar: "baz" },
     });


### PR DESCRIPTION
This adds support for `route`

Since `route` and `pathname` are always exactly the same we can use the same values for both.  

