### PR TITLE
Eliminate dependency on Node's `url` and `querystring` and use `URL` and `URLSearchParams`

### DIFF
--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -1,20 +1,14 @@
-import mitt, { MittEmitter } from "./lib/mitt";
-import { parse as parseUrl, UrlWithParsedQuery } from "url";
-import { ParsedUrlQuery, stringify as stringifyQueryString } from "querystring";
-
 import type { NextRouter, RouterEvent } from "next/router";
+import mitt, { MittEmitter } from "./lib/mitt";
+import { parseUrl, stringifyQueryString } from "./urls";
 
 export type Url = string | UrlObject;
 export type UrlObject = {
-  pathname?: UrlWithParsedQuery["pathname"];
-  query?: UrlWithParsedQuery["query"];
-  hash?: UrlWithParsedQuery["hash"];
+  pathname?: string;
+  query?: NextRouter["query"];
+  hash?: string;
 };
-export type UrlObjectComplete = {
-  pathname: NonNullable<UrlWithParsedQuery["pathname"]>;
-  query: NonNullable<UrlWithParsedQuery["query"]>;
-  hash: NonNullable<UrlWithParsedQuery["hash"]>;
-};
+export type UrlObjectComplete = Required<UrlObject>;
 
 // interface not exported by the package next/router
 interface TransitionOptions {
@@ -211,7 +205,7 @@ export class MemoryRouter extends BaseRouter {
  * Normalizes the url or urlObject into a UrlObjectComplete.
  */
 function parseUrlToCompleteUrl(url: Url, currentPathname: string): UrlObjectComplete {
-  const parsedUrl = typeof url === "object" ? url : parseUrl(url, true);
+  const parsedUrl = typeof url === "object" ? url : parseUrl(url);
   return {
     pathname: removeTrailingSlash(parsedUrl.pathname ?? currentPathname),
     query: parsedUrl.query || {},
@@ -223,7 +217,7 @@ function parseUrlToCompleteUrl(url: Url, currentPathname: string): UrlObjectComp
  * Creates a URL from a pathname + query.
  * Injects query params into the URL slugs, the same way that next/router does.
  */
-function getRouteAsPath(pathname: string, query: ParsedUrlQuery, hash: string | null | undefined) {
+function getRouteAsPath(pathname: string, query: NextRouter["query"], hash: string | null | undefined) {
   const remainingQuery = { ...query };
 
   // Replace slugs, and remove them from the `query`

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,0 +1,16 @@
+import type { NextRouter } from "next/router";
+import type { UrlObject } from "./MemoryRouter";
+
+export function parseUrl(url: string): UrlObject {
+  const base = "https://base.com"; // base can be anything
+  const parsed = new URL(url, base);
+  const query = Object.fromEntries(parsed.searchParams);
+  return {
+    pathname: parsed.pathname,
+    hash: parsed.hash,
+    query,
+  };
+}
+export function stringifyQueryString(query: NextRouter["query"]): string {
+  return new URLSearchParams(query as Record<string, string>).toString();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2019", "DOM", "DOM.Iterable"], /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
# What
- Removes the dependency on Node's built-in `url` and `querystring` modules
- This allows the package to work in Storybook without needing polyfills
- Addresses #72 