### PR TITLE
Fix: ensure a hash-only change gets rerendered

### DIFF
--- a/src/useMemoryRouter.test.tsx
+++ b/src/useMemoryRouter.test.tsx
@@ -60,6 +60,22 @@ export function useRouterTests(singletonRouter: MemoryRouter, useRouter: () => M
     });
   });
 
+  it('changing just the "hash" will cause a rerender', async () => {
+    const { result } = renderHook(() => useRouter());
+
+    await act(async () => {
+      await result.current.push("/foo");
+      await result.current.push("/foo#bar");
+    });
+    const expected = {
+      asPath: "/foo#bar",
+      pathname: "/foo",
+      hash: "#bar",
+    };
+    expect(singletonRouter).toMatchObject(expected);
+    expect(result.current).toMatchObject(expected);
+  });
+
   it('calling "push" multiple times will rerender with the correct route', async () => {
     const { result } = renderHook(() => useRouter());
 

--- a/src/useMemoryRouter.tsx
+++ b/src/useMemoryRouter.tsx
@@ -27,9 +27,11 @@ export const useMemoryRouter = (singletonRouter: MemoryRouter, eventHandlers?: M
     };
 
     singletonRouter.events.on("routeChangeComplete", handleRouteChange);
+    singletonRouter.events.on("hashChangeComplete", handleRouteChange);
     return () => {
       isMounted = false;
       singletonRouter.events.off("routeChangeComplete", handleRouteChange);
+      singletonRouter.events.off("hashChangeComplete", handleRouteChange);
     };
   }, [singletonRouter]);
 


### PR DESCRIPTION
# What
Ensures a hash-only change will trigger a component rerender
Addresses #84 