### PR TITLE
repro: failing test for multi-valued parameters

### DIFF
--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -339,6 +339,22 @@ describe("MemoryRouter", () => {
         });
       });
 
+      it("multiple values can be specified for a query parameter", () => {
+        memoryRouter.setCurrentUrl("/url?foo=FOO&foo=BAR");
+        expect(memoryRouter).toMatchObject({
+          asPath: "/url?foo=FOO&foo=BAR",
+          query: {
+            foo: ["FOO", "BAR"],
+          },
+        });
+
+        memoryRouter.setCurrentUrl({ pathname: "/object-notation", query: { foo: ["BAR", "BAZ"] } });
+        expect(memoryRouter).toMatchObject({
+          asPath: "/object-notation?foo=BAR&foo=BAZ",
+          query: { foo: ["BAR", "BAZ"] },
+        });
+      });
+
       describe('the "as" parameter', () => {
         it('works fine without "as" param', async () => {
           await memoryRouter.push("/path?queryParam=123");

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -34,5 +34,17 @@ describe("next/link", () => {
         });
       });
     });
+
+    it("supports multivalued query properties", async () => {
+      render(<NextLink href={{ pathname: "/example", query: { foo: ["bar", "baz"] } }}>Next Link</NextLink>, { wrapper });
+      fireEvent.click(screen.getByText("Next Link"));
+      await waitFor(() => {
+        expect(memoryRouter).toMatchObject({
+          asPath: "/example?foo=bar&foo=baz",
+          pathname: "/example",
+          query: { foo: ["bar", "baz"] },
+        });
+      });
+    });
   });
 });

--- a/src/next-link.test.tsx
+++ b/src/next-link.test.tsx
@@ -36,7 +36,9 @@ describe("next/link", () => {
     });
 
     it("supports multivalued query properties", async () => {
-      render(<NextLink href={{ pathname: "/example", query: { foo: ["bar", "baz"] } }}>Next Link</NextLink>, { wrapper });
+      render(<NextLink href={{ pathname: "/example", query: { foo: ["bar", "baz"] } }}>Next Link</NextLink>, {
+        wrapper,
+      });
       fireEvent.click(screen.getByText("Next Link"));
       await waitFor(() => {
         expect(memoryRouter).toMatchObject({

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -4,7 +4,12 @@ import type { UrlObject } from "./MemoryRouter";
 export function parseUrl(url: string): UrlObject {
   const base = "https://base.com"; // base can be anything
   const parsed = new URL(url, base);
-  const query = Object.fromEntries(parsed.searchParams);
+  const query = Object.fromEntries(
+    Array.from(parsed.searchParams.keys()).map((key) => {
+      const values = parsed.searchParams.getAll(key);
+      return [key, values.length === 1 ? values[0] : values];
+    })
+  );
   return {
     pathname: parsed.pathname,
     hash: parsed.hash,
@@ -12,5 +17,12 @@ export function parseUrl(url: string): UrlObject {
   };
 }
 export function stringifyQueryString(query: NextRouter["query"]): string {
-  return new URLSearchParams(query as Record<string, string>).toString();
+  const params = new URLSearchParams();
+  Object.keys(query).forEach((key) => {
+    const values = query[key];
+    for (const value of Array.isArray(values) ? values : [values]) {
+      params.append(key, value!);
+    }
+  });
+  return params.toString();
 }


### PR DESCRIPTION
starting with 0.9.4, multi-valued query parameters don't seem to work anymore - is that on purpose? am I doing something wrong?

added a failing test for reproduction.