### PR TITLE
docs(README): replace require with jest.requireActual

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import { useRouter } from 'next/router';
 import { render, screen, fireEvent } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 
-jest.mock("next/router", () => jest.requireActual("next-router-mock"))
+jest.mock('next/router', () => jest.requireActual('next-router-mock'))
 
 const ExampleComponent = ({ href = '' }) => {
   const router = useRouter();

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import { useRouter } from 'next/router';
 import { render, screen, fireEvent } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 
-jest.mock('next/router', () => require('next-router-mock'));
+jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
 const ExampleComponent = ({ href = '' }) => {
   const router = useRouter();


### PR DESCRIPTION
Use `jest.requireActual` to avoid using a CommonJS `require` statement .

In my TS project, ESLint was shouting at me when using `require`: https://typescript-eslint.io/rules/no-var-requires

Using `requireActual` resolved this:

```ts
jest.mock("next/router", () => jest.requireActual<MemoryRouter>("next-router-mock"));
```
