### PR TITLE
Tests: add more 'as' param tests

### DIFF
--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -371,29 +371,22 @@ describe("MemoryRouter", () => {
         });
 
         it('works with the "as" param', async () => {
-          await memoryRouter.push("/real-path", "/as-path");
+          await memoryRouter.push("/path", "/path?param=as");
           expectMatch(memoryRouter, {
-            asPath: "/as-path",
-            pathname: "/as-path",
+            asPath: "/path?param=as",
+            pathname: "/path",
             query: {},
           });
 
-          await memoryRouter.push("/real-path?param=real", "/as-path?param=as");
+          await memoryRouter.push("/path", { pathname: "/path", query: { param: "as" } });
           expectMatch(memoryRouter, {
-            asPath: "/as-path?param=as",
-            pathname: "/as-path",
-            query: { param: "as" },
-          });
-
-          await memoryRouter.push("/real-path", "");
-          expectMatch(memoryRouter, {
-            asPath: "/",
-            pathname: "/",
+            asPath: "/path?param=as",
+            pathname: "/path",
             query: {},
           });
         });
 
-        it("if as path matches href path, href query is used", async () => {
+        it("the real query is always used", async () => {
           await memoryRouter.push("/path?queryParam=123", "/path");
           expectMatch(memoryRouter, {
             asPath: "/path",
@@ -401,11 +394,11 @@ describe("MemoryRouter", () => {
             query: { queryParam: "123" },
           });
 
-          await memoryRouter.push("/path?queryParam=123", { pathname: "/path" });
+          await memoryRouter.push("/path", "/path?queryParam=123");
           expectMatch(memoryRouter, {
-            asPath: "/path",
+            asPath: "/path?queryParam=123",
             pathname: "/path",
-            query: { queryParam: "123" },
+            query: {},
           });
 
           await memoryRouter.push("/path?queryParam=123", "/path?differentQueryParam=456");
@@ -430,6 +423,22 @@ describe("MemoryRouter", () => {
             asPath: "/",
             pathname: "/",
             query: { queryParam: "123" },
+          });
+        });
+
+        it("dynamic paths get correct parameters", async () => {
+          await memoryRouter.push("/[[...route]]", "/noe/two/three");
+          expectMatch(memoryRouter, {
+            asPath: "/one/two/three",
+            pathname: "/[[...route]]",
+            query: { route: ["one", "two", "three"] },
+          });
+
+          await memoryRouter.push({ pathname: "/[[...route]]", query: { param: "href" } }, "/one/two/three");
+          expectMatch(memoryRouter, {
+            asPath: "/one/two/three",
+            pathname: "/[[...route]]",
+            query: { param: "href", route: ["one", "two", "three"] },
           });
         });
 

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -1,4 +1,5 @@
 import { MemoryRouter } from "./MemoryRouter";
+import { expectMatch } from "../test/test-utils";
 
 describe("MemoryRouter", () => {
   beforeEach(() => {
@@ -360,17 +361,7 @@ describe("MemoryRouter", () => {
       });
 
       describe('the "as" parameter', () => {
-        it('works fine without "as" param', async () => {
-          // Just a sanity check
-          await memoryRouter.push("/path?queryParam=123");
-          expectMatch(memoryRouter, {
-            asPath: "/path?queryParam=123",
-            pathname: "/path",
-            query: { queryParam: "123" },
-          });
-        });
-
-        it('works with the "as" param', async () => {
+        it("works with strings or objects", async () => {
           await memoryRouter.push("/path", "/path?param=as");
           expectMatch(memoryRouter, {
             asPath: "/path?param=as",
@@ -426,22 +417,6 @@ describe("MemoryRouter", () => {
           });
         });
 
-        it("dynamic paths get correct parameters", async () => {
-          await memoryRouter.push("/[[...route]]", "/noe/two/three");
-          expectMatch(memoryRouter, {
-            asPath: "/one/two/three",
-            pathname: "/[[...route]]",
-            query: { route: ["one", "two", "three"] },
-          });
-
-          await memoryRouter.push({ pathname: "/[[...route]]", query: { param: "href" } }, "/one/two/three");
-          expectMatch(memoryRouter, {
-            asPath: "/one/two/three",
-            pathname: "/[[...route]]",
-            query: { param: "href", route: ["one", "two", "three"] },
-          });
-        });
-
         describe("when the paths don't match", () => {
           it("as path and query is used", async () => {
             await memoryRouter.push("/path?queryParam=123", "/differentPath?differentQueryParam=456");
@@ -463,7 +438,7 @@ describe("MemoryRouter", () => {
           });
         });
 
-        it("as param hash overrides href hash", async () => {
+        it('"as" param hash overrides "url" hash', async () => {
           await memoryRouter.push("/path", "/path#hash");
           expectMatch(memoryRouter, {
             asPath: "/path#hash",
@@ -566,26 +541,3 @@ describe("MemoryRouter", () => {
     });
   });
 });
-
-/**
- * Performs a partial equality comparison.
- *
- * This is similar to using `toMatchObject`, but doesn't ignore missing `query: { ... }` values!
- */
-function expectMatch(memoryRouter: MemoryRouter, expected: Partial<MemoryRouter>): void {
-  const picked = pick(memoryRouter, Object.keys(expected) as Array<keyof MemoryRouter>);
-  try {
-    expect(picked).toEqual(expected);
-  } catch (err: any) {
-    // Ensure stack trace is accurate:
-    Error.captureStackTrace(err, expectMatch);
-    throw err;
-  }
-}
-function pick<T extends object>(obj: T, keys: Array<keyof T>): T {
-  const result = {} as T;
-  keys.forEach((key) => {
-    result[key] = obj[key];
-  });
-  return result;
-}

--- a/src/dynamic-routes/createDynamicRouteParser.test.tsx
+++ b/src/dynamic-routes/createDynamicRouteParser.test.tsx
@@ -1,5 +1,6 @@
 import { MemoryRouter } from "../MemoryRouter";
 import { createDynamicRouteParser } from "./next-12";
+import { expectMatch } from "../../test/test-utils";
 
 describe("dynamic routes", () => {
   let memoryRouter: MemoryRouter;
@@ -11,7 +12,7 @@ describe("dynamic routes", () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]/attribute/[name]", "/[...slug]"]));
 
     memoryRouter.push("/entity/101/attribute/everything");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]/attribute/[name]",
       asPath: "/entity/101/attribute/everything",
       query: {
@@ -25,7 +26,7 @@ describe("dynamic routes", () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]/attribute/[name]", "/[...slug]"]));
 
     memoryRouter.push("/one/two/three");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/[...slug]",
       asPath: "/one/two/three",
       query: {
@@ -38,7 +39,7 @@ describe("dynamic routes", () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]/attribute/[name]"]));
 
     memoryRouter.push("/one/two/three");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/one/two/three",
       asPath: "/one/two/three",
       query: {},
@@ -49,7 +50,7 @@ describe("dynamic routes", () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]", "/entity/list"]));
 
     memoryRouter.push("/entity/list");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/list",
       asPath: "/entity/list",
       query: {},
@@ -61,7 +62,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/entity/100?id=500");
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]",
       query: { id: "100" },
       asPath: "/entity/100?id=500",
@@ -73,7 +74,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push({ pathname: "/entity/[id]", query: { id: "42" } });
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]",
       asPath: "/entity/42",
       query: { id: "42" },
@@ -85,7 +86,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push({ pathname: "/entity/[id]", query: { id: "42", filter: "abc" } });
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]",
       asPath: "/entity/42?filter=abc",
       query: { id: "42", filter: "abc" },
@@ -97,7 +98,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push({ pathname: "/[...slug]", query: { slug: ["one", "two", "three"] } });
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/[...slug]",
       asPath: "/one/two/three",
       query: { slug: ["one", "two", "three"] },
@@ -109,7 +110,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push({ pathname: "/entity/100", query: { filter: "abc", max: "1000" } });
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]",
       asPath: "/entity/100?filter=abc&max=1000",
       query: { id: "100", filter: "abc", max: "1000" },
@@ -121,7 +122,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/one/two/three/four");
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/one/two/[[...slug]]",
       asPath: "/one/two/three/four",
       query: { slug: ["three", "four"] },
@@ -133,7 +134,7 @@ describe("dynamic routes", () => {
 
     memoryRouter.push("/entity/42");
 
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       pathname: "/entity/[id]/[[...slug]]",
       asPath: "/entity/42",
       query: { id: "42" },
@@ -141,11 +142,23 @@ describe("dynamic routes", () => {
   });
 
   describe('the "as" parameter', () => {
-    it("uses as path param over href path param", async () => {
+    it('uses "as" path param over "url" path param', async () => {
       memoryRouter.useParser(createDynamicRouteParser(["/path/[testParam]"]));
 
       memoryRouter.push("/path/123", "/path/456");
-      expect(memoryRouter).toMatchObject({
+      expectMatch(memoryRouter, {
+        asPath: "/path/456",
+        pathname: "/path/[testParam]",
+        query: {
+          testParam: "456",
+        },
+      });
+    });
+    it('uses "as" path param with a dynamic route', async () => {
+      memoryRouter.useParser(createDynamicRouteParser(["/path/[testParam]"]));
+
+      memoryRouter.push("/path/[testParam]", "/path/456");
+      expectMatch(memoryRouter, {
         asPath: "/path/456",
         pathname: "/path/[testParam]",
         query: {
@@ -159,14 +172,14 @@ describe("dynamic routes", () => {
     memoryRouter.useParser(createDynamicRouteParser(["/entity/[id]"]));
 
     memoryRouter.setCurrentUrl("/entity/42#hash");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       asPath: "/entity/42#hash",
       pathname: "/entity/[id]",
       hash: "#hash",
     });
 
     memoryRouter.setCurrentUrl("/entity/42?key=value#hash");
-    expect(memoryRouter).toMatchObject({
+    expectMatch(memoryRouter, {
       asPath: "/entity/42?key=value#hash",
       pathname: "/entity/[id]",
       query: { key: "value", id: "42" },

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,25 @@
+import type { MemoryRouter } from "../src/MemoryRouter";
+
+/**
+ * Performs a partial equality comparison.
+ *
+ * This is similar to using `toMatchObject`, but doesn't ignore missing `query: { ... }` values!
+ */
+export function expectMatch(memoryRouter: MemoryRouter, expected: Partial<MemoryRouter>): void {
+  const picked = pick(memoryRouter, Object.keys(expected) as Array<keyof MemoryRouter>);
+  try {
+    expect(picked).toEqual(expected);
+  } catch (err: any) {
+    // Ensure stack trace is accurate:
+    Error.captureStackTrace(err, expectMatch);
+    throw err;
+  }
+}
+
+function pick<T extends object>(obj: T, keys: Array<keyof T>): T {
+  const result = {} as T;
+  keys.forEach((key) => {
+    result[key] = obj[key];
+  });
+  return result;
+}


### PR DESCRIPTION
Adds more test cases for using the `as` parameter.
Only tests have been changed.