### PR TITLE
fix: update UrlObject type to match native url module

### DIFF
--- a/.changeset/thick-feet-return.md
+++ b/.changeset/thick-feet-return.md
@@ -1,0 +1,5 @@
+---
+"next-router-mock": patch
+---
+
+fix: update UrlObject type to match native url module

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -4,7 +4,7 @@ import { parseUrl, stringifyQueryString } from "./urls";
 
 export type Url = string | UrlObject;
 export type UrlObject = {
-  pathname?: string;
+  pathname?: string | null | undefined;
   query?: NextRouter["query"];
   hash?: string;
 };


### PR DESCRIPTION
This PR updates the library's own `UrlObject` to match the type defined in the native `url` module. `UrlObject` is defined in @types/node [v16](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0818c3f7de545c6b6431e9745dd9910618bba918/types/node/v16/url.d.ts#L15), [v18](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0818c3f7de545c6b6431e9745dd9910618bba918/types/node/v18/url.d.ts#L15) and [latest](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0818c3f7de545c6b6431e9745dd9910618bba918/types/node/url.d.ts#L15) as:

```ts
interface UrlObject {
    auth?: string | null | undefined;
    hash?: string | null | undefined;
    host?: string | null | undefined;
    hostname?: string | null | undefined;
    href?: string | null | undefined;
    pathname?: string | null | undefined;
    protocol?: string | null | undefined;
    search?: string | null | undefined;
    slashes?: boolean | null | undefined;
    port?: string | number | null | undefined;
    query?: string | null | ParsedUrlQueryInput | undefined;
}
```

This should fix type issues trying to use `url` `UrlObject` with `next-router-mock`:

<img width="887" alt="image" src="https://github.com/scottrippey/next-router-mock/assets/111427669/60f750af-491a-4ea1-81c5-99127faebd49"> 

Related: https://github.com/scottrippey/next-router-mock/pull/82