### PR TITLE
Use async singleton router for MemoryRouterProvider

### DIFF
--- a/.changeset/few-news-jam.md
+++ b/.changeset/few-news-jam.md
@@ -1,0 +1,5 @@
+---
+"next-router-mock": patch
+---
+
+Enable MemoryRouterProvider to use the async singleton

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.9",
+  "version": "0.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-router-mock",
-      "version": "0.9.9",
+      "version": "0.9.11",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.12",
+  "version": "0.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-router-mock",
-      "version": "0.9.12",
+      "version": "0.9.11",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-router-mock",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.12",
+  "version": "0.9.11",
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/index",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/index",
   "files": [

--- a/src/MemoryRouterProvider/MemoryRouterProvider.async.test.tsx
+++ b/src/MemoryRouterProvider/MemoryRouterProvider.async.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useRouter } from "next/router";
+import NextLink, { LinkProps } from "next/link";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { MemoryRouterProvider } from "./index";
+import { default as singletonRouter } from "../async";
+
+const TestLink = (linkProps: Partial<LinkProps>) => {
+  const router = useRouter();
+  return (
+    <NextLink href="/test" {...linkProps}>
+      Current route: "{router.asPath}"
+    </NextLink>
+  );
+};
+
+describe("MemoryRouterProvider", () => {
+  beforeEach(() => {
+    singletonRouter.setCurrentUrl("/initial");
+  });
+
+  it("should provide a router", () => {
+    render(
+      <MemoryRouterProvider async>
+        <TestLink />
+      </MemoryRouterProvider>
+    );
+    expect(screen.getByText(`Current route: "/initial"`)).toBeDefined();
+  });
+
+  it("using the singleton router should update the URL", async () => {
+    render(
+      <MemoryRouterProvider async>
+        <TestLink />
+      </MemoryRouterProvider>
+    );
+
+    // Navigate:
+    expect(screen.getByText(`Current route: "/initial"`)).toBeDefined();
+    await act(async () => await singletonRouter.push("/new-route"));
+    await waitFor(() => expect(screen.getByText(`Current route: "/new-route"`)).toBeDefined());
+  });
+
+  it("clicking a link should navigate to the new URL", async () => {
+    render(
+      <MemoryRouterProvider async>
+        <TestLink />
+      </MemoryRouterProvider>
+    );
+    expect(screen.getByText(`Current route: "/initial"`)).toBeDefined();
+    fireEvent.click(screen.getByText(`Current route: "/initial"`));
+    await waitFor(() => expect(screen.getByText(`Current route: "/test"`)).toBeDefined());
+  });
+
+  describe("url", () => {
+    it("an initial URL can be supplied", () => {
+      render(
+        <MemoryRouterProvider url="/example" async>
+          <TestLink />
+        </MemoryRouterProvider>
+      );
+      expect(screen.getByText(`Current route: "/example"`)).toBeDefined();
+    });
+
+    it("an initial URL Object can be supplied", () => {
+      render(
+        <MemoryRouterProvider url={{ pathname: "/example", query: { foo: "bar" } }} async>
+          <TestLink />
+        </MemoryRouterProvider>
+      );
+      expect(screen.getByText(`Current route: "/example?foo=bar"`)).toBeDefined();
+    });
+  });
+
+  describe("events", () => {
+    const eventHandlers = {
+      onPush: jest.fn(),
+      onReplace: jest.fn(),
+      onRouteChangeStart: jest.fn(),
+      onRouteChangeComplete: jest.fn(),
+    };
+    beforeEach(async () => {
+      jest.clearAllMocks();
+    });
+    it("clicking a link should trigger the correct event handlers", async () => {
+      render(
+        <MemoryRouterProvider url="/initial" async {...eventHandlers}>
+          <TestLink />
+        </MemoryRouterProvider>
+      );
+      fireEvent.click(screen.getByText(`Current route: "/initial"`));
+      await waitFor(() => expect(screen.getByText(`Current route: "/test"`)).not.toBeNull());
+      expect(eventHandlers.onPush).toHaveBeenCalledWith("/test", { shallow: false });
+      expect(eventHandlers.onReplace).not.toHaveBeenCalled();
+      expect(eventHandlers.onRouteChangeStart).toHaveBeenCalledWith("/test", { shallow: false });
+      expect(eventHandlers.onRouteChangeComplete).toHaveBeenCalledWith("/test", { shallow: false });
+    });
+    it("a 'replace' link triggers the correct handlers too", async () => {
+      render(
+        <MemoryRouterProvider url="/initial" async {...eventHandlers}>
+          <TestLink replace />
+        </MemoryRouterProvider>
+      );
+      fireEvent.click(screen.getByText(`Current route: "/initial"`));
+      await waitFor(() => expect(screen.getByText(`Current route: "/test"`)).not.toBeNull());
+      expect(eventHandlers.onPush).not.toHaveBeenCalledWith("/test", { shallow: false });
+      expect(eventHandlers.onReplace).toHaveBeenCalled();
+      expect(eventHandlers.onRouteChangeStart).toHaveBeenCalledWith("/test", { shallow: false });
+      expect(eventHandlers.onRouteChangeComplete).toHaveBeenCalledWith("/test", { shallow: false });
+    });
+  });
+});

--- a/src/MemoryRouterProvider/MemoryRouterProvider.tsx
+++ b/src/MemoryRouterProvider/MemoryRouterProvider.tsx
@@ -1,6 +1,7 @@
 import React, { FC, ReactNode, useMemo } from "react";
 
 import { useMemoryRouter, MemoryRouter, Url, default as singletonRouter } from "../index";
+import { default as asyncSingletonRouter } from "../async";
 import { MemoryRouterEventHandlers } from "../useMemoryRouter";
 import { MemoryRouterContext } from "../MemoryRouterContext";
 
@@ -28,7 +29,7 @@ export function factory(dependencies: AbstractedNextDependencies) {
         return new MemoryRouter(url, async);
       }
       // Normally we'll just use the singleton:
-      return singletonRouter;
+      return async ? asyncSingletonRouter : singletonRouter;
     }, [url, async]);
 
     const routerSnapshot = useMemoryRouter(memoryRouter, eventHandlers);


### PR DESCRIPTION
We are using the `next-router-mock/async` provider and had a bunch of issues with the Provider, as it appeared all manipulations of the router get ignored by our components.

Looking into the code, I discovered why: The `<MemoryRouterProvider />` ignores the `async` prop unless an `url` is given. However, when an `url` is given, a new router is created.

This should return the async singleton when requested - however, I could not test if it works for our application as I couldn't figure out how to include the package without it being published.