### PR TITLE
Add history support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "next-router-mock",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-router-mock",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
+      "dependencies": {
+        "history": "^5.3.0"
+      },
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@testing-library/react": "^13.4.0",
@@ -406,7 +409,6 @@
       "version": "7.22.10",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
       "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -4335,6 +4337,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -7614,8 +7624,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -10317,7 +10326,6 @@
       "version": "7.22.10",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
       "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -13470,6 +13478,14 @@
         }
       }
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -15941,8 +15957,7 @@
     "regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "history": "^5.3.0"
   }
 }

--- a/src/MemoryRouter.test.tsx
+++ b/src/MemoryRouter.test.tsx
@@ -1,5 +1,6 @@
 import { MemoryRouter } from "./MemoryRouter";
 import { expectMatch } from "../test/test-utils";
+import { createMemoryHistory } from "history";
 
 describe("MemoryRouter", () => {
   beforeEach(() => {
@@ -533,6 +534,42 @@ describe("MemoryRouter", () => {
           pathname: "/path",
           query: { key: "value" },
           hash: "#hash",
+        });
+      });
+
+      describe("history sync router", () => {
+        it("push", async () => {
+          const history = createMemoryHistory();
+          memoryRouter.setCurrentHistory(history);
+          expect(memoryRouter.asPath).toEqual("/");
+          expect(memoryRouter.history.index).toEqual(0);
+
+          await memoryRouter.push("/one?foo=bar");
+          expect(memoryRouter.asPath).toEqual("/one?foo=bar");
+          expect(memoryRouter.history.index).toEqual(1);
+
+          await memoryRouter.push("/two");
+          expect(memoryRouter.asPath).toEqual("/two");
+          expect(memoryRouter.history.index).toEqual(2);
+
+          await memoryRouter.push("/three#hash");
+          expect(memoryRouter.asPath).toEqual("/three#hash");
+          expect(memoryRouter.history.index).toEqual(3);
+        });
+
+        it("replace", async () => {
+          const history = createMemoryHistory({ initialEntries: ["/one"] });
+          memoryRouter.setCurrentHistory(history);
+          expect(memoryRouter.asPath).toEqual("/one");
+          expect(memoryRouter.history.index).toEqual(0);
+
+          await memoryRouter.push("/two");
+          expect(memoryRouter.asPath).toEqual("/two");
+          expect(memoryRouter.history.index).toEqual(1);
+
+          await memoryRouter.replace("/three");
+          expect(memoryRouter.asPath).toEqual("/three");
+          expect(memoryRouter.history.index).toEqual(1); // replace does not add a new entry
         });
       });
 

--- a/src/MemoryRouter.tsx
+++ b/src/MemoryRouter.tsx
@@ -1,4 +1,5 @@
 import type { NextRouter, RouterEvent } from "next/router";
+import { createMemoryHistory, type MemoryHistory } from "history";
 import mitt, { MittEmitter } from "./lib/mitt";
 import { parseUrl, stringifyQueryString } from "./urls";
 
@@ -32,6 +33,14 @@ type InternalEventTypes =
   /** Emitted when 'router.replace' is called */
   | "NEXT_ROUTER_MOCK:replace";
 
+type RouterState = {
+  asPath: string;
+  pathname: string;
+  query: NextRouter["query"];
+  hash: string;
+  locale?: string;
+};
+
 /**
  * A base implementation of NextRouter that does nothing; all methods throw.
  */
@@ -44,6 +53,11 @@ export abstract class BaseRouter implements NextRouter {
    * It is only supplied as part of next-router-mock, for the sake of testing
    */
   hash = "";
+  /**
+   * The `_history` property is NOT part of NextRouter.
+   * It is only supplied as part of next-router-mock, for the sake of testing
+   */
+  _history: MemoryHistory = createMemoryHistory();
 
   // These are constant:
   isReady = true;
@@ -92,10 +106,11 @@ export class MemoryRouter extends BaseRouter {
     return Object.assign(new MemoryRouter(), original);
   }
 
-  constructor(initialUrl?: Url, async?: boolean) {
+  constructor(initialUrl?: Url, async?: boolean, history?: MemoryHistory) {
     super();
     if (initialUrl) this.setCurrentUrl(initialUrl);
     if (async) this.async = async;
+    if (history) this.setCurrentHistory(history);
   }
 
   /**
@@ -131,6 +146,84 @@ export class MemoryRouter extends BaseRouter {
   replace = (url: Url, as?: Url, options?: TransitionOptions) => {
     return this._setCurrentUrl(url, as, options, "replace");
   };
+
+  /**
+   * Sets the current MemoryHistory.
+   */
+  public setCurrentHistory = (history: MemoryHistory) => {
+    this._history = history;
+    this.setCurrentUrl(history.location.pathname + history.location.search + history.location.hash);
+  };
+
+  /**
+   * Returns the current MemoryHistory.
+   * history.state property represents the previous location's state in MemoryHistory.
+   */
+  get history() {
+    return {
+      ...this._history,
+      createHref(to) {
+        throw new Error("You cannot use history.createHref() because it is a stateless.");
+      },
+      push(to, state) {
+        throw new Error("You cannot use history.push() because it is a stateless.");
+      },
+      replace(to, state) {
+        throw new Error("You cannot use history.replace() because it is a stateless.");
+      },
+      go(delta) {
+        throw new Error("You cannot use history.go() because it is a stateless.");
+      },
+      back() {
+        throw new Error("You cannot use history.back() because it is a stateless.");
+      },
+      forward() {
+        throw new Error("You cannot use history.forward() because it is a stateless.");
+      },
+      listen() {
+        throw new Error("You cannot use history.listen() because it is a stateless.");
+      },
+      block(blocker) {
+        throw new Error("You cannot use history.block() because it is a stateless.");
+      },
+    } satisfies MemoryHistory;
+  }
+
+  /**
+   * Store the current MemoryHistory state to history.state for the next location.
+   */
+  private _updateHistory(source?: "push" | "replace" | "set") {
+    switch (source) {
+      case "push":
+        this._history.push(this._state.asPath, this._state);
+        break;
+      case "replace":
+        this._history.replace(this._state.asPath, this._state);
+        break;
+      case "set":
+        this._history = createMemoryHistory({ initialEntries: [this._state.asPath] });
+        break;
+      // TODO: support back
+    }
+  }
+
+  private get _state(): RouterState {
+    return {
+      asPath: this.asPath,
+      pathname: this.pathname,
+      query: this.query,
+      hash: this.hash,
+      locale: this.locale,
+    };
+  }
+
+  private _updateState(asPath: string, route: UrlObjectComplete, locale: TransitionOptions["locale"]) {
+    this.asPath = asPath;
+    this.pathname = route.pathname;
+    this.query = { ...route.query, ...route.routeParams };
+    this.hash = route.hash;
+    if (locale) this.locale = locale;
+  }
 
   /**
    * Sets the current Memory route to the specified url, synchronously.
@@ -179,15 +272,10 @@ export class MemoryRouter extends BaseRouter {
     // Simulate the async nature of this method
     if (async) await new Promise((resolve) => setTimeout(resolve, 0));
 
+    // Store the current state as the previous state. (must be called before "_updateState"!!!)
+    this._updateHistory(source);
     // Update this instance:
-    this.asPath = asPath;
-    this.pathname = newRoute.pathname;
-    this.query = { ...newRoute.query, ...newRoute.routeParams };
-    this.hash = newRoute.hash;
-
-    if (options?.locale) {
-      this.locale = options.locale;
-    }
+    this._updateState(asPath, newRoute, options?.locale);
 
     // Fire "complete" event:
     if (triggerHashChange) {

--- a/src/MemoryRouterProvider/MemoryRouterProvider.tsx
+++ b/src/MemoryRouterProvider/MemoryRouterProvider.tsx
@@ -4,6 +4,7 @@ import { useMemoryRouter, MemoryRouter, Url, default as singletonRouter } from "
 import { default as asyncSingletonRouter } from "../async";
 import { MemoryRouterEventHandlers } from "../useMemoryRouter";
 import { MemoryRouterContext } from "../MemoryRouterContext";
+import { MemoryHistory } from "history";
 
 type AbstractedNextDependencies = Pick<
   typeof import("next/dist/shared/lib/router-context.shared-runtime"),
@@ -16,21 +17,26 @@ export type MemoryRouterProviderProps = {
    */
   url?: Url;
   async?: boolean;
+  history?: MemoryHistory;
   children?: ReactNode;
 } & MemoryRouterEventHandlers;
 
 export function factory(dependencies: AbstractedNextDependencies) {
   const { RouterContext } = dependencies;
 
-  const MemoryRouterProvider: FC<MemoryRouterProviderProps> = ({ children, url, async, ...eventHandlers }) => {
+  const MemoryRouterProvider: FC<MemoryRouterProviderProps> = ({ children, url, async, history, ...eventHandlers }) => {
     const memoryRouter = useMemo(() => {
       if (typeof url !== "undefined") {
         // If the `url` was specified, we'll use an "isolated router" instead of the singleton.
-        return new MemoryRouter(url, async);
+        return new MemoryRouter(url, async, undefined);
+      }
+      if (typeof history !== "undefined") {
+        // If the `history` was specified, we'll use an "isolated router" instead of the singleton.
+        return new MemoryRouter(undefined, async, history);
       }
       // Normally we'll just use the singleton:
       return async ? asyncSingletonRouter : singletonRouter;
-    }, [url, async]);
+    }, [url, async, history]);
 
     const routerSnapshot = useMemoryRouter(memoryRouter, eventHandlers);
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -17,11 +17,13 @@ describe("next-overridable-hook", () => {
       push: expect.any(Function),
       replace: expect.any(Function),
       setCurrentUrl: expect.any(Function),
+      setCurrentHistory: expect.any(Function),
       registerPaths: expect.any(Function),
       // Ensure the router has exactly these properties:
       asPath: "/",
       basePath: "",
       hash: "",
+      _history: expect.any(Object),
       isFallback: false,
       isLocaleDomain: false,
       isPreview: false,

--- a/src/useMemoryRouter.test.tsx
+++ b/src/useMemoryRouter.test.tsx
@@ -143,6 +143,26 @@ export function useRouterTests(singletonRouter: MemoryRouter, useRouter: () => M
     });
     expect(result.current.locale).toBe("en");
   });
+
+  it("following history", async () => {
+    const { result } = renderHook(() => useRouter());
+    result.current.setCurrentUrl("/")
+    await act(async () => {
+      await result.current.push("/one");
+    });
+    expect(result.current.history.index).toBe(1);
+
+    await act(async () => {
+      await result.current.push("/two");
+      await result.current.push("/three");
+    });
+    expect(result.current.history.index).toBe(3);
+
+    await act(async () => {
+      await result.current.replace("/four");
+    });
+    expect(result.current.history.index).toBe(3); // replace does not change history index
+  })
 }
 
 describe("useMemoryRouter", () => {


### PR DESCRIPTION
## Introduction

This PR proposes to support `history` in anticipation of `router.back()` support.
A picture of future support is envisioned ([like this code](https://github.com/ergofriend/next-router-mock/pull/1/files)).

As described in [the React Router testing guide](https://v5.reactrouter.com/web/guides/testing/react-testing-library), React Router previously allowed explicit tracking of navigation history by passing the history object.

Ideally, centralizing state in the history object would eliminate the need for manual history restoration.

However, this pull request only implements location history recording at this stage.



## Breaking Changes

- Added [remix-run/history: Manage session history with JavaScript](https://github.com/remix-run/history) to dependencies
  - To enable history by default for future router.back() support
- Added `history` property to MemoryRouter
  - To allow access to history that updates with routing changes

This pull request change allows us to test the following...

```ts
        it("replace", async () => {
          const history = createMemoryHistory({ initialEntries: ["/one"] });
          memoryRouter.setCurrentHistory(history);
          expect(memoryRouter.asPath).toEqual("/one");
          expect(memoryRouter.history.index).toEqual(0);

          await memoryRouter.push("/two");
          expect(memoryRouter.asPath).toEqual("/two");
          expect(memoryRouter.history.index).toEqual(1);

          await memoryRouter.replace("/three");
          expect(memoryRouter.asPath).toEqual("/three");
          expect(memoryRouter.history.index).toEqual(1); // replace does not add a new entry
        });
```

## Concerns
- Additional dependencies on `history`
- Complicated state management

I would appreciate your input on the above concerns, as I think they are concerns.
Thanks in advance!
