### PR TITLE
docs: fix broken link to `react-router`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An implementation of the Next.js Router that keeps the state of the "URL" in memory (does not read or write to the
 address bar).  Useful in **tests** and **Storybook**. 
-Inspired by [`react-router > MemoryRouter`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/MemoryRouter.md).
+Inspired by [`react-router > MemoryRouter`](https://github.com/remix-run/react-router/blob/main/docs/router-components/memory-router.md).
 
 Tested with NextJS v13, v12, v11, and v10.
 


### PR DESCRIPTION
First of all, thank you for creating and maintaining this wonderful package.

I looking this package, and found tiny issue, so i made this PR.
The link to "react-router" in "README" was broken because the URL of the linked repository had changed, so I fixed it.
