### PR TITLE
Update README.md - fix code examples to use the correct of the testing-library matcher - toHaveTextContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ it('NextLink can be rendered', () => {
     <NextLink href="/example">Example Link</NextLink>, 
     { wrapper: MemoryRouterProvider }
   );
-  fireEvent.click(screen.getByTextContent('Example Link'));
+  fireEvent.click(screen.getByText('Example Link'));
   expect(mockRouter.asPath).toEqual('/example')
 });
 ```
@@ -262,7 +262,7 @@ too; for example:
 ```jsx
 it('next/link can be tested too', async () => {
   render(<NextLink href="/example?foo=bar"><a>Example Link</a></NextLink>);
-  fireEvent.click(screen.getByTextContent('Example Link'));
+  fireEvent.click(screen.getByText('Example Link'));
   await waitFor(() => {
     expect(singletonRouter).toMatchObject({
       asPath: '/example?foo=bar',

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ describe('next-router-mock', () => {
     
     // Render the component:
     render(<ExampleComponent href="/foo?bar=baz" />);
-    expect(screen.getByRole('button')).toHaveText(
+    expect(screen.getByRole('button')).toHaveTextContent(
       'The current route is: "/initial-path"'
     );
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ it('NextLink can be rendered', () => {
     <NextLink href="/example">Example Link</NextLink>, 
     { wrapper: MemoryRouterProvider }
   );
-  fireEvent.click(screen.getByText('Example Link'));
+  fireEvent.click(screen.getByTextContent('Example Link'));
   expect(mockRouter.asPath).toEqual('/example')
 });
 ```
@@ -262,7 +262,7 @@ too; for example:
 ```jsx
 it('next/link can be tested too', async () => {
   render(<NextLink href="/example?foo=bar"><a>Example Link</a></NextLink>);
-  fireEvent.click(screen.getByText('Example Link'));
+  fireEvent.click(screen.getByTextContent('Example Link'));
   await waitFor(() => {
     expect(singletonRouter).toMatchObject({
       asPath: '/example?foo=bar',


### PR DESCRIPTION
The correct matcher is `toHaveTextContent` https://github.com/testing-library/jest-dom?tab=readme-ov-file#tohavetextcontent not `toHaveText`