### PR TITLE
chore: update package.json exports to include TypeScript types

### DIFF
--- a/.changeset/selfish-doors-carry.md
+++ b/.changeset/selfish-doors-carry.md
@@ -1,0 +1,5 @@
+---
+"next-router-mock": patch
+---
+
+chore: update package.json exports to include TypeScript types

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist"
+      "default": "./dist/index.js"
     },
     "./*": "./dist/*",
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Mock implementation of the Next.js Router",
   "main": "dist/index",
   "exports": {
-    ".": "./dist",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist"
+    },
     "./*": "./dist/*",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Hello!
I always use your library, thank you!

After updating to “1.0.0”, I could not find the type definition file and got an [error](https://github.com/taro-28/tanstack-table-search-params/actions/runs/14924726878/job/41926905552?pr=527), so I added “types” to exports.